### PR TITLE
Call for Help Ability: Fix shenanigans w/ spawn position (both in-world & in-combat)

### DIFF
--- a/Assets/Game/VFX/Shaders/BattleEntry/BattleEntryShader.mat
+++ b/Assets/Game/VFX/Shaders/BattleEntry/BattleEntryShader.mat
@@ -53,7 +53,7 @@ Material:
     - _DecalMeshViewBias: 0
     - _DrawOrder: 0
     - _DstBlend: 10
-    - _Phase: 0.9599997
+    - _Phase: 3.8159645
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1

--- a/Assets/Scripts/Control/NPC/NPCStateHandler.cs
+++ b/Assets/Scripts/Control/NPC/NPCStateHandler.cs
@@ -130,6 +130,11 @@ namespace Frankie.Control
         {
             InitiateDialogue(playerStateHandler.value);
         }
+
+        public void ForceNPCOccupied()
+        {
+            npcOccupied = true;
+        }
         #endregion
 
         #region PrivateMethods


### PR DESCRIPTION
In-Combat:  Bug with setting row/column positioning causing invalid enemyMapping indices

In-World:  Enemies spawned as 'active' (no player state change to force occupied) -- so needed to force occupied && disable colliders