### PR TITLE
CU-868f2gvrj :: Remove the need for node-to-node traversal for zone transitions

### DIFF
--- a/Assets/Scripts/Zones/Room.cs
+++ b/Assets/Scripts/Zones/Room.cs
@@ -19,7 +19,7 @@ namespace Frankie.ZoneManagement
             if (disableOnStart && !stateSetBySave && !stateSetByZoneHandler) { gameObject.SetActive(false); }
         }
 
-        public void FlagEnabledByZoneHandler() { stateSetByZoneHandler = true; }
+        public void FlagStateSetByZoneHandler() { stateSetByZoneHandler = true; }
 
         public LoadPriority GetLoadPriority()
         {
@@ -38,8 +38,7 @@ namespace Frankie.ZoneManagement
 
             bool roomEnabled = (bool)saveState.GetState(typeof(bool));
             gameObject.SetActive(roomEnabled);
-
-            if (saveState != null) { stateSetBySave = true; }
+            stateSetBySave = true;
         }
     }
 }


### PR DESCRIPTION
## Issue:
In current implementation, if we want to transition to a new zone, we:
* traverse to the new node
* check the new node for the zone reference
* if it exists, then move to the new zone/scene
* otherwise, treat as a normal in-zone node transition

This results in the creation of unnecessary source nodes that have no real purpose other than to traverse to the linked node for scene transitions.  This is complicated and confusing for two reasons:
1. Naming of the source node vs. the transition node is weird/usually overlappy
2. When linking zone nodes, we normally need to link to the source node, but it's easy to make the mistake of linking to the scene transition node

## Solution:
Update the logic of node traversal to first check if the source node has scene references, and then traverse to the linked node (if not)