### PR TITLE
CU-868fr3mmz :: Add cooldownStore Concept for Cooldown Timer

### DIFF
--- a/Assets/Scenes/_Debug/TEST_BattleRoyale.unity
+++ b/Assets/Scenes/_Debug/TEST_BattleRoyale.unity
@@ -4582,7 +4582,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4736094180608794019, guid: 71d598481a579c2448140b70660e15c0, type: 3}
       propertyPath: checkInteraction.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: InitiateCombat
+      value: InitiateCombatAdvantaged
       objectReference: {fileID: 0}
     - target: {fileID: 4736094180608794019, guid: 71d598481a579c2448140b70660e15c0, type: 3}
       propertyPath: rejectInteraction.m_PersistentCalls.m_Calls.Array.data[0].m_CallState

--- a/Assets/Scripts/Combat/BattleAction/Effects/CallForHelp.cs
+++ b/Assets/Scripts/Combat/BattleAction/Effects/CallForHelp.cs
@@ -41,7 +41,7 @@ namespace Frankie.Combat
 
                 if (spawnedEnemy.TryGetComponent(out CombatParticipant enemy))
                 {
-                    battleController.AddEnemyToCombat(enemy, false, true);
+                    battleController.AddEnemyToCombat(enemy, ZoneManagement.TransitionType.BattleNeutral, true);
                     friendFound = true;
                 }
                 else

--- a/Assets/Scripts/Combat/BattleEvents/Events/BattleEnterEvent.cs
+++ b/Assets/Scripts/Combat/BattleEvents/Events/BattleEnterEvent.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Frankie.ZoneManagement;
 
 namespace Frankie.Combat
 {
@@ -8,11 +9,13 @@ namespace Frankie.Combat
 
         public List<BattleEntity> playerEntities { get; private set; }
         public List<BattleEntity> enemyEntities { get; private set; }
+        public TransitionType transitionType;
 
-        public BattleEnterEvent(List<BattleEntity> playerEntities, List<BattleEntity> enemyEntities)
+        public BattleEnterEvent(List<BattleEntity> playerEntities, List<BattleEntity> enemyEntities, TransitionType transitionType)
         {
             this.playerEntities = playerEntities;
             this.enemyEntities = enemyEntities;
+            this.transitionType = transitionType;
         }
     }
 }

--- a/Assets/Scripts/Combat/CombatParticipant/CombatParticipant.cs
+++ b/Assets/Scripts/Combat/CombatParticipant/CombatParticipant.cs
@@ -34,7 +34,7 @@ namespace Frankie.Combat
         [SerializeField] float cooldownAtBattleStart = 2.5f;
         [SerializeField] float cooldownBattleAdvantageAdder = -4.0f;
         [SerializeField] float cooldownBattleDisadvantageAdder = 4.0f;
-        [SerializeField] float cooldownRunFailureAdder = 3.0f;
+        [SerializeField] float cooldownRunFailAdder = 5.0f;
 
         // Cached References
         BaseStats baseStats = null;
@@ -234,9 +234,9 @@ namespace Frankie.Combat
             UnityEngine.Debug.Log($"Post-Reconcile:  Cooldown @ {cooldownTimer}, Store @ {cooldownStore}");
         }
 
-        public void SetCooldownStoreForRun()
+        public void IncrementCooldownStoreForRun()
         {
-            cooldownStore += cooldownRunFailureAdder;
+            cooldownStore += cooldownRunFailAdder;
             ReconcileCooldownStore();
         }
 

--- a/Assets/Scripts/Control/NPC/NPCStateHandler.cs
+++ b/Assets/Scripts/Control/NPC/NPCStateHandler.cs
@@ -114,6 +114,16 @@ namespace Frankie.Control
             InitiateCombat(playerStateHandler, TransitionType.BattleNeutral);
         }
 
+        public void InitiateCombatAdvantaged(PlayerStateMachine playerStateHandler)  // called via Unity Event
+        {
+            InitiateCombat(playerStateHandler, TransitionType.BattleGood);
+        }
+
+        public void InitiateCombatDisadvantaged(PlayerStateMachine playerStateHandler)  // called via Unity Event
+        {
+            InitiateCombat(playerStateHandler, TransitionType.BattleBad);
+        }
+
         public void InitiateCombat(TransitionType transitionType) // called via Unity Event
         {
             InitiateCombat(playerStateHandler.value, transitionType);

--- a/Assets/Scripts/Saving/SerializableVector2.cs
+++ b/Assets/Scripts/Saving/SerializableVector2.cs
@@ -13,6 +13,18 @@ namespace Frankie.Saving
             y = vector.y;
         }
 
+        public SerializableVector2(Vector2 vector)
+        {
+            x = vector.x;
+            y = vector.y;
+        }
+
+        public SerializableVector2(float x, float y)
+        {
+            this.x = x;
+            this.y = y;
+        }        
+
         public Vector2 ToVector()
         {
             return new Vector2(x, y);

--- a/Assets/Scripts/Stats/CalculatedStat.cs
+++ b/Assets/Scripts/Stats/CalculatedStat.cs
@@ -10,6 +10,7 @@ namespace Frankie.Stats
         MagicalAdder,
         Defense,
         RunSpeed, // in-battle speed
+        RunChance, // contested chance based on speed
         Fearsome, // cause enemies to flee
         Imposing, // cause battles to auto-win
         MoveSpeed // in-world speed

--- a/Assets/Scripts/Stats/CalculatedStats.cs
+++ b/Assets/Scripts/Stats/CalculatedStats.cs
@@ -8,7 +8,7 @@ namespace Frankie.Stats
     {
         // Note:  Equations  have a lot of magic numbers for shaping
         // Hard limits provided as static tunables here
-        static float cooldownMultiplierMin = 0.5f;
+        static float cooldownMultiplierMin = 0.2f;
         static float cooldownMultiplierMax = 4f;
         static float hitChanceMin = 0.2f;
         static float hitChanceMax = 1.0f;

--- a/Assets/Scripts/Stats/CalculatedStats.cs
+++ b/Assets/Scripts/Stats/CalculatedStats.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Frankie.Stats
@@ -28,6 +26,7 @@ namespace Frankie.Stats
                 CalculatedStat.Defense => Stat.Nimble,
                 CalculatedStat.MoveSpeed => Stat.Nimble,
                 CalculatedStat.RunSpeed => Stat.Pluck,
+                CalculatedStat.RunChance => Stat.Pluck,
                 CalculatedStat.Fearsome => Stat.Pluck,
                 CalculatedStat.Imposing => Stat.Pluck,
                 _ => Stat.ExperienceReward,
@@ -51,6 +50,7 @@ namespace Frankie.Stats
                 CalculatedStat.Defense => GetDefense(callerModifier),
                 CalculatedStat.MoveSpeed => GetMoveSpeed(level, callerModifier),
                 CalculatedStat.RunSpeed => GetRunSpeed(callerModifier),
+                CalculatedStat.RunChance => GetRunChance(callerModifier, contestModifier),
                 CalculatedStat.Fearsome => GetFearsome(callerModifier, contestModifier),
                 CalculatedStat.Imposing => GetImposing(callerModifier, contestModifier),
                 _ => 0f,
@@ -106,16 +106,21 @@ namespace Frankie.Stats
             return Mathf.Max(0f, modifier);
         }
 
+        private static float GetRunChance(float modifier, float contestModifier)
+        {
+            return Mathf.Min(1.0f, 2 * modifier / (3 * contestModifier));
+        }
+
         private static float GetFearsome(float modifier, float defenderModifier)
         {
             // positive value = fearsome (multiplier* more than defender)
-            return modifier - 6 * defenderModifier;
+            return modifier - 3 * defenderModifier;
         }
 
         private static float GetImposing(float modifier, float defenderModifier)
         {
             // positive value -> imposing (multiplier* more than defender)
-            return modifier - 12 * defenderModifier;
+            return modifier - 6 * defenderModifier;
         }
         #endregion
     }


### PR DESCRIPTION
## High-Level Idea

- several actions (battle start, battle end, running, etc.) will now modify cooldownStore instead of cooldown directly (both +ve and -ve)
- when updating cooldown, these cooldownTimer will modify itself and pull from this store to a min or max amount

## Purpose

This allows us to have an incremental downside for e.g. run attempts, without completely resetting the cooldown.  This should also add future flexibility for skills (e.g. skill to grant multiple free attacks can add a large negative value into the store).