### PR TITLE
Playtest Bug Fixes:  More fader and game over state shenanigans

### DIFF
--- a/Assets/AddressableAssetsData/Linux.meta
+++ b/Assets/AddressableAssetsData/Linux.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 04b83ff4e11134deca93d4d4bffe4365
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Portabank.unity
+++ b/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Portabank.unity
@@ -1193,7 +1193,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1290031699}
   - {fileID: 1035204890}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1347,89 +1346,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d92d50962782bba45b45ae165ed31395, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Control.Specialization.WorldSaver
---- !u!1 &1290031698
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1290031699}
-  - component: {fileID: 1290031700}
-  m_Layer: 2
-  m_Name: CameraBounds
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1290031699
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1290031698}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1040580543}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!60 &1290031700
-PolygonCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1290031698}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Points:
-    m_Paths:
-    - - {x: 6.2498217, y: 3.667341}
-      - {x: -5.780162, y: 3.5508003}
-      - {x: -5.6801934, y: -3.6378133}
-      - {x: 6.40597, y: -3.6223075}
-  m_UseDelaunayMesh: 0
 --- !u!1001 &1323364250
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2211,7 +2127,7 @@ PrefabInstance:
     - target: {fileID: 6748405756017321321, guid: 7d6634333e185754d96c189f3df7c163, type: 3}
       propertyPath: m_BoundingShape2D
       value: 
-      objectReference: {fileID: 1290031700}
+      objectReference: {fileID: 0}
     - target: {fileID: 6748405756206951134, guid: 7d6634333e185754d96c189f3df7c163, type: 3}
       propertyPath: m_RootOrder
       value: 1
@@ -2275,7 +2191,7 @@ PrefabInstance:
     - target: {fileID: 6748405756263700703, guid: 7d6634333e185754d96c189f3df7c163, type: 3}
       propertyPath: m_BoundingShape2D
       value: 
-      objectReference: {fileID: 1290031700}
+      objectReference: {fileID: 0}
     - target: {fileID: 6748405756474271262, guid: 7d6634333e185754d96c189f3df7c163, type: 3}
       propertyPath: orthographic size
       value: 2.4

--- a/Assets/Scripts/Control/Player/PlayerStateMachine/PlayerStates/CutSceneState.cs
+++ b/Assets/Scripts/Control/Player/PlayerStateMachine/PlayerStates/CutSceneState.cs
@@ -10,8 +10,9 @@ namespace Frankie.Control.PlayerStates
 
         public void EnterCutScene(IPlayerStateContext playerStateContext)
         {
-            // No state change (will dequeue next time in world)
+            // Queue then kick to world to bump next cutscene immediately
             playerStateContext.QueueActionUnderConsideration();
+            EnterWorld(playerStateContext);
         }
 
         public void EnterDialogue(IPlayerStateContext playerStateContext)

--- a/Assets/Scripts/World/Core/WorldFaderInterface.cs
+++ b/Assets/Scripts/World/Core/WorldFaderInterface.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using UnityEngine;
 using Frankie.Control;
@@ -7,11 +8,21 @@ namespace Frankie.World
 {
     public class WorldFaderInterface : MonoBehaviour
     {
+        // Tunables
         [SerializeField] private float blipFadeHoldSeconds = 1.0f;
+
+        // State
+        private Coroutine activeFade;
         
+        private void OnDisable()
+        {
+            if (activeFade != null) { StopCoroutine(activeFade); }
+        }
+
         public void StartBlipFade(PlayerStateMachine playerStateMachine)
         {
-            StartCoroutine(BlipFade(playerStateMachine));
+            if (activeFade != null) { StopCoroutine(activeFade); }
+            activeFade = StartCoroutine(BlipFade(playerStateMachine));
         }
 
         private IEnumerator BlipFade(PlayerStateMachine playerStateMachine)

--- a/Assets/Scripts/Zones/Fader.cs
+++ b/Assets/Scripts/Zones/Fader.cs
@@ -21,8 +21,9 @@ namespace Frankie.ZoneManagement
         [SerializeField] private float zoneFadeTimerMultiplier = 0.25f;
 
         // State
-        private Image currentTransitionImage;
         private bool fading = false;
+        private Coroutine activeFade;
+        private Image currentTransitionImage;
         private Action initiateBattleCallback;
 
         // Cached References
@@ -56,6 +57,11 @@ namespace Frankie.ZoneManagement
             sceneLoader.ForceInit();
             ResetOverlays();
         }
+
+        private void OnDisable()
+        {
+            if (activeFade != null) { StopCoroutine(activeFade); }
+        }
         #endregion
 
         #region PublicMethods
@@ -75,13 +81,15 @@ namespace Frankie.ZoneManagement
         {
             // Non-IEnumerator Type for Scene Transitions:
             // Coroutine needs to exist on an object that will persist between scenes
-            StartCoroutine(ZoneFade(transitionType, nextZone, saveSession));
+            if (activeFade != null) { StopCoroutine(activeFade); }
+            activeFade = StartCoroutine(ZoneFade(transitionType, nextZone, saveSession));
         }
 
         public void UpdateFadeStateImmediate()
         {
             // Coroutine needs to exist on an object that will persist between scenes
-            StartCoroutine(FadeImmediate());
+            if (activeFade != null) { StopCoroutine(activeFade); }
+            activeFade = StartCoroutine(FadeImmediate());
         }
 
         public IEnumerator QueueFadeEntry(TransitionType transitionType)

--- a/Assets/Settings/Build Profiles/Demo_Forest-Linux.asset
+++ b/Assets/Settings/Build Profiles/Demo_Forest-Linux.asset
@@ -10,14 +10,14 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 15003, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: Demo_Forest-Mac
+  m_Name: Demo_Forest-Linux
   m_EditorClassIdentifier: UnityEditor.dll::UnityEditor.Build.Profile.BuildProfile
   m_AssetVersion: 1
-  m_BuildTarget: 2
+  m_BuildTarget: 24
   m_Subtarget: 2
-  m_PlatformId: 0d2129357eac403d8b359c2dcbf82502
+  m_PlatformId: cb423bfea44b4d658edb8bc5d91a3024
   m_PlatformBuildProfile:
-    rid: 3751081976599937096
+    rid: 5769979868454060033
   m_OverrideGlobalSceneList: 1
   m_Scenes:
   - m_enabled: 1
@@ -43,8 +43,8 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 3751081976599937096
-      type: {class: OSXStandaloneBuildProfile, ns: UnityEditor.OSXStandalone, asm: UnityEditor.OSXStandalone.Extensions}
+    - rid: 5769979868454060033
+      type: {class: LinuxPlatformSettings, ns: UnityEditor.LinuxStandalone, asm: UnityEditor.LinuxStandalone.Extensions}
       data:
         m_Development: 0
         m_ConnectProfiler: 0
@@ -60,6 +60,10 @@ MonoBehaviour:
         m_InsightsSettingsContainer:
           m_BuildProfileEngineDiagnosticsState: 2
         m_AdaptivePerformanceEnabled: 0
-        m_MacOSXcodeBuildConfig: 1
-        m_Architecture: 2
-        m_CreateXcodeProject: 0
+        m_Architecture: 0
+        m_RemoteDeviceSectionFoldoutOpen: 0
+        m_DeployTarget: 0
+        m_RemoteDeviceAddress: 
+        m_RemoteDeviceUsername: 
+        m_RemoteDeviceExports: 
+        m_PathOnRemoteDevice: 

--- a/Assets/Settings/Build Profiles/Demo_Forest-Linux.asset.meta
+++ b/Assets/Settings/Build Profiles/Demo_Forest-Linux.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b7858022e453f4968a0d6e9f2920f524
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Settings/Build Profiles/Demo_Forest-Windows.asset
+++ b/Assets/Settings/Build Profiles/Demo_Forest-Windows.asset
@@ -46,7 +46,7 @@ MonoBehaviour:
     - rid: 339555978758588447
       type: {class: WindowsPlatformSettings, ns: UnityEditor.WindowsStandalone, asm: UnityEditor.WindowsStandalone.Extensions}
       data:
-        m_Development: 1
+        m_Development: 0
         m_ConnectProfiler: 0
         m_BuildWithDeepProfilingSupport: 0
         m_AllowDebugging: 0


### PR DESCRIPTION
- Avoid null reference issues on fader by keeping coroutine state and stopping coroutines as-needed
- Prevent player world interactions in between death and game over scene loading
- Clear queued actions on zone transitions