### PR TITLE
CU-868ju407b :: Escape Menu QoL Improvements - Confirm changes popup & better language selection

### DIFF
--- a/Assets/Game/UI/Inventory/InventorySwapBox.prefab
+++ b/Assets/Game/UI/Inventory/InventorySwapBox.prefab
@@ -558,7 +558,6 @@ MonoBehaviour:
   optionParent: {fileID: 2827520980706274898}
   optionButtonPrefab: {fileID: 3358873790910023875, guid: 9193413aa0e976e439049a2689f4fa41, type: 3}
   optionSliderPrefab: {fileID: 4136279713418740174, guid: 4a7bed0c126f347b0865033b4042eab0, type: 3}
-  sliderAdjustmentStep: 0.1
   selectedCharacterNameField: {fileID: 3511601292740054661}
   leftItemContainer: {fileID: 4808833409950686781}
   rightItemContainer: {fileID: 2801211723359414022}
@@ -658,9 +657,9 @@ MonoBehaviour:
     m_LocalVariables: []
   localizedMessageConfirmThrowOut:
     m_TableReference:
-      m_TableCollectionName: 
+      m_TableCollectionName: GUID:ce7f667b432574cb1832328f600c1082
     m_TableEntryReference:
-      m_KeyId: 0
+      m_KeyId: 15233195644542976
       m_Key: 
     m_FallbackState: 0
     m_WaitForCompletion: 0

--- a/Assets/Game/UI/MainMenus/InWorld/OptionsMenu.prefab
+++ b/Assets/Game/UI/MainMenus/InWorld/OptionsMenu.prefab
@@ -363,7 +363,6 @@ MonoBehaviour:
   optionParent: {fileID: 2133087926795939164}
   optionButtonPrefab: {fileID: 3358873790910023875, guid: 9193413aa0e976e439049a2689f4fa41, type: 3}
   optionSliderPrefab: {fileID: 4136279713418740174, guid: 4a7bed0c126f347b0865033b4042eab0, type: 3}
-  sliderAdjustmentStep: 0.1
   localizedOptionsHeader:
     m_TableReference:
       m_TableCollectionName: GUID:ce7f667b432574cb1832328f600c1082
@@ -463,7 +462,7 @@ MonoBehaviour:
   fullScreenWindowedToggle: {fileID: 2288194241731149846}
   resolutionOptionsParent: {fileID: 7763845387748952643}
   languageHeaderField: {fileID: 3625833196065374036}
-  languageOptionsParent: {fileID: 6005714132217539989}
+  languageOptionsContainer: {fileID: 6782008398968980446}
   confirmOption: {fileID: 2741238634633839223}
   cancelOption: {fileID: 1461409793377961888}
   defaultMasterVolume: 0.8
@@ -530,68 +529,6 @@ MonoBehaviour:
     m_Bottom: 10
   m_ChildAlignment: 4
   m_Spacing: 10
-  m_ChildForceExpandWidth: 0
-  m_ChildForceExpandHeight: 0
-  m_ChildControlWidth: 1
-  m_ChildControlHeight: 1
-  m_ChildScaleWidth: 1
-  m_ChildScaleHeight: 1
-  m_ReverseArrangement: 0
---- !u!1 &6920202102955963044
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6005714132217539989}
-  - component: {fileID: 2689486286004597821}
-  m_Layer: 0
-  m_Name: LanguageFields
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &6005714132217539989
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6920202102955963044}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2133087926795939164}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &2689486286004597821
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6920202102955963044}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.HorizontalLayoutGroup
-  m_Padding:
-    m_Left: 40
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 4
-  m_Spacing: 20
   m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 0
   m_ChildControlWidth: 1
@@ -1213,6 +1150,119 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4109057552186186554, guid: 4a7bed0c126f347b0865033b4042eab0, type: 3}
   m_PrefabInstance: {fileID: 24542248592193847}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &209060819657908597
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2133087926795939164}
+    m_Modifications:
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7129132861876114385, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+      propertyPath: m_Name
+      value: LanguageFields
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+--- !u!224 &6005714132217539989 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5890196602504072416, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+  m_PrefabInstance: {fileID: 209060819657908597}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6782008398968980446 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6699160529269318315, guid: c959f4b021e7e45528e1400cd69b163b, type: 3}
+  m_PrefabInstance: {fileID: 209060819657908597}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42a6e35bbcdd4f2e886a079b0931493e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Frankie.Utils.UI.UIChoiceContainer
 --- !u!1001 &1150308309202606831
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Game/UI/MainMenus/InWorld/OptionsMenu.prefab
+++ b/Assets/Game/UI/MainMenus/InWorld/OptionsMenu.prefab
@@ -453,6 +453,15 @@ MonoBehaviour:
     m_FallbackState: 0
     m_WaitForCompletion: 0
     m_LocalVariables: []
+  localizedConfirmChangesText:
+    m_TableReference:
+      m_TableCollectionName: GUID:ce7f667b432574cb1832328f600c1082
+    m_TableEntryReference:
+      m_KeyId: 15133689565405184
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
   optionsHeaderField: {fileID: 444034996801310822}
   masterVolumeSlider: {fileID: 1304911131375114066}
   backgroundVolumeSlider: {fileID: 4815048910335752979}
@@ -465,6 +474,7 @@ MonoBehaviour:
   languageOptionsContainer: {fileID: 6782008398968980446}
   confirmOption: {fileID: 2741238634633839223}
   cancelOption: {fileID: 1461409793377961888}
+  dialogueOptionBoxPrefab: {fileID: 3084176042462386772, guid: cfcc3c74158936342a4d3c72aa65bde0, type: 3}
   defaultMasterVolume: 0.8
   defaultBackgroundVolume: 0.5
   defaultSoundEffectsVolume: 0.3

--- a/Assets/Game/UI/MainMenus/InWorld/WorldOptions.prefab
+++ b/Assets/Game/UI/MainMenus/InWorld/WorldOptions.prefab
@@ -361,7 +361,6 @@ MonoBehaviour:
   optionParent: {fileID: 3567840514475693783}
   optionButtonPrefab: {fileID: 3358873790910023875, guid: 9193413aa0e976e439049a2689f4fa41, type: 3}
   optionSliderPrefab: {fileID: 4136279713418740174, guid: 4a7bed0c126f347b0865033b4042eab0, type: 3}
-  sliderAdjustmentStep: 0.1
   localizedKnapsackText:
     m_TableReference:
       m_TableCollectionName: GUID:ce7f667b432574cb1832328f600c1082

--- a/Assets/Game/UI/Utilities/UIChoiceContainer.prefab
+++ b/Assets/Game/UI/Utilities/UIChoiceContainer.prefab
@@ -1,0 +1,180 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7129132861876114385
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5890196602504072416}
+  - component: {fileID: 2860984446436234568}
+  - component: {fileID: 6699160529269318315}
+  m_Layer: 0
+  m_Name: UIChoiceContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5890196602504072416
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7129132861876114385}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6746807921668445504}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2860984446436234568
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7129132861876114385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.HorizontalLayoutGroup
+  m_Padding:
+    m_Left: 40
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 20
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 1
+  m_ChildScaleHeight: 1
+  m_ReverseArrangement: 0
+--- !u!114 &6699160529269318315
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7129132861876114385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42a6e35bbcdd4f2e886a079b0931493e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Frankie.Utils.UI.UIChoiceContainer
+  selectionMarker: {fileID: 587053370915415545, guid: 9193413aa0e976e439049a2689f4fa41, type: 3}
+  choiceOrder: 0
+  validChoiceColor: {r: 1, g: 1, b: 1, a: 1}
+  invalidChoiceColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  textField: {fileID: 8228735411345103475, guid: 4a7bed0c126f347b0865033b4042eab0, type: 3}
+  itemHighlighted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6746807921668445519}
+        m_TargetAssemblyTypeName: Frankie.Sound.SoundEffects, Assembly-CSharp
+        m_MethodName: PlayClip
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  isMoveHorizontal: 1
+--- !u!1001 &9040545955192321635
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5890196602504072416}
+    m_Modifications:
+    - target: {fileID: 2366363061461443362, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+      propertyPath: m_Name
+      value: OnHighlightSoundbox
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366363061461443363, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366363061461443363, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366363061461443363, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -75
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366363061461443363, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366363061461443363, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366363061461443363, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366363061461443363, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366363061461443363, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366363061461443363, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366363061461443363, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366363061461443363, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366363061461443372, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+      propertyPath: 'audioClips.Array.data[0]'
+      value: 
+      objectReference: {fileID: 8300000, guid: a8d807a7fc1c07643a42980dde1ffbdc, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+--- !u!4 &6746807921668445504 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2366363061461443363, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+  m_PrefabInstance: {fileID: 9040545955192321635}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6746807921668445519 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2366363061461443372, guid: 9fe4f716a2cae1644a0e1dc7d044c757, type: 3}
+  m_PrefabInstance: {fileID: 9040545955192321635}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d92abaff543d4a4498f7173bd00113e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Game/UI/Utilities/UIChoiceContainer.prefab.meta
+++ b/Assets/Game/UI/Utilities/UIChoiceContainer.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c959f4b021e7e45528e1400cd69b163b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/VFX/Shaders/BattleEntry/BattleEntryByURP.mat
+++ b/Assets/Game/VFX/Shaders/BattleEntry/BattleEntryByURP.mat
@@ -49,10 +49,10 @@ Material:
     - _FadeOutTime: 0.75
     - _FadeTime: 3.5
     - _GraphicStrengthMod: 2
-    - _Phase: 2.2799993
+    - _Phase: 111.32825
     - _Strength: 30
     - _ToggleFade: 0
-    - _ToggleFadeOut: 0
+    - _ToggleFadeOut: 1
     m_Colors: []
   m_BuildTextureStacks: []
   m_AllowLocking: 1

--- a/Assets/Game/VFX/Shaders/BattleEntry/BattleEntryByURP.mat
+++ b/Assets/Game/VFX/Shaders/BattleEntry/BattleEntryByURP.mat
@@ -24,7 +24,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: e1b549b5625cd6c49baa09e79d3f1ef0, type: 3}
+        m_Texture: {fileID: 2800000, guid: 48853a5670350a84bb46b94fcdb31459, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _Texture2DAsset_38ffba9e9f644a5085b23c6a6b1b814b_Out_0_Texture2D:
@@ -49,7 +49,7 @@ Material:
     - _FadeOutTime: 0.75
     - _FadeTime: 3.5
     - _GraphicStrengthMod: 2
-    - _Phase: 30.159988
+    - _Phase: 2.2799993
     - _Strength: 30
     - _ToggleFade: 0
     - _ToggleFadeOut: 0

--- a/Assets/Localization/Table_UI/UI Shared Data.asset
+++ b/Assets/Localization/Table_UI/UI Shared Data.asset
@@ -479,6 +479,10 @@ MonoBehaviour:
     m_Key: BattleCanvas.Prefab.Battle Canvas.MessageFailedToRun.68c95a38
     m_Metadata:
       m_Items: []
+  - m_Id: 15133689565405184
+    m_Key: OptionsMenu.Prefab.OptionsMenu.ConfirmChangesText.2a77de74
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Localization/Table_UI/UI Shared Data.asset
+++ b/Assets/Localization/Table_UI/UI Shared Data.asset
@@ -135,10 +135,6 @@ MonoBehaviour:
     m_Key: CombatOptions.Prefab.CombatOptions.RunawayText.5c54e191
     m_Metadata:
       m_Items: []
-  - m_Id: 8999697510293504
-    m_Key: SkillSelectionUI.Prefab.SkillSelection.NoSkillSelectionText.189c0169
-    m_Metadata:
-      m_Items: []
   - m_Id: 9002459291705344
     m_Key: AbilitiesBox.Prefab.AbilitiesBox.StatLabel.43e2453f
     m_Metadata:
@@ -481,6 +477,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 15133689565405184
     m_Key: OptionsMenu.Prefab.OptionsMenu.ConfirmChangesText.2a77de74
+    m_Metadata:
+      m_Items: []
+  - m_Id: 15233195644542976
+    m_Key: InventorySwapBox.Prefab.InventorySwapBox.MessageConfirmThrowOut.179a247
     m_Metadata:
       m_Items: []
   m_Metadata:

--- a/Assets/Localization/Table_UI/UI_en.asset
+++ b/Assets/Localization/Table_UI/UI_en.asset
@@ -139,10 +139,6 @@ MonoBehaviour:
     m_Localized: Run Away
     m_Metadata:
       m_Items: []
-  - m_Id: 8999697510293504
-    m_Localized: No Selection
-    m_Metadata:
-      m_Items: []
   - m_Id: 9002459291705344
     m_Localized: 'Inclination:  '
     m_Metadata:
@@ -486,6 +482,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 15133689565405184
     m_Localized: Save changes to options?
+    m_Metadata:
+      m_Items: []
+  - m_Id: 15233195644542976
+    m_Localized: Will you chuck {1} in order to pick up {0}?
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Localization/Table_UI/UI_en.asset
+++ b/Assets/Localization/Table_UI/UI_en.asset
@@ -484,6 +484,10 @@ MonoBehaviour:
     m_Localized: Failed to run away.
     m_Metadata:
       m_Items: []
+  - m_Id: 15133689565405184
+    m_Localized: Save changes to options?
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Localization/Table_UI/UI_fr.asset
+++ b/Assets/Localization/Table_UI/UI_fr.asset
@@ -140,10 +140,6 @@ MonoBehaviour:
     m_Localized: Fuir
     m_Metadata:
       m_Items: []
-  - m_Id: 8999697510293504
-    m_Localized: "Aucune s\xE9lection"
-    m_Metadata:
-      m_Items: []
   - m_Id: 9002459291705344
     m_Localized: 'Inclination :'
     m_Metadata:
@@ -482,6 +478,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 15133689565405184
     m_Localized: Sauvegarder les modifications des options?
+    m_Metadata:
+      m_Items: []
+  - m_Id: 15233195644542976
+    m_Localized: Veux-tu jeter {1} pour ramasser {0} ?
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Localization/Table_UI/UI_fr.asset
+++ b/Assets/Localization/Table_UI/UI_fr.asset
@@ -480,6 +480,10 @@ MonoBehaviour:
     m_Localized: Impossible de prendre la fuite.
     m_Metadata:
       m_Items: []
+  - m_Id: 15133689565405184
+    m_Localized: Sauvegarder les modifications des options?
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Scripts/Stats/Party/PartyCombatConduit.cs
+++ b/Assets/Scripts/Stats/Party/PartyCombatConduit.cs
@@ -46,6 +46,7 @@ namespace Frankie.Stats
         public List<CombatParticipant> GetPartyAssistParticipants() => combatAssistCache;
 
         public string GetPartyLeaderName() => party?.GetPartyLeaderName() ?? "";
+        public bool IsPartySolo() => party.GetPartySize() == 1;
 
         public bool IsAnyMemberAlive()
         {

--- a/Assets/Scripts/UI/Combat/CombatOptions.cs
+++ b/Assets/Scripts/UI/Combat/CombatOptions.cs
@@ -68,7 +68,7 @@ namespace Frankie.Combat.UI
         public void OpenKnapsack() // Called via unity events
         {
             InventoryBox inventoryBox = Instantiate(inventoryBoxPrefab, battleCanvas.transform);
-            inventoryBox.Setup(battleController, partyCombatConduit);
+            inventoryBox.Setup(battleController, partyCombatConduit, null);
             PassControl(this, new Action[] { EnableCombatOptions }, inventoryBox, battleController);
             gameObject.SetActive(false);
         }

--- a/Assets/Scripts/UI/Inventory/Equipment/EquipmentBox.cs
+++ b/Assets/Scripts/UI/Inventory/Equipment/EquipmentBox.cs
@@ -44,10 +44,13 @@ namespace Frankie.Inventory.UI
         [SerializeField][SimpleLocalizedString(LocalizationTableType.UI, true)] private LocalizedString localizedOptionEquip;
         [SerializeField][SimpleLocalizedString(LocalizationTableType.UI, true)] private LocalizedString localizedOptionRemove;
 
-        // State
+        // State -- UI
         private EquipmentBoxState equipmentBoxState = EquipmentBoxState.InCharacterSelection;
         private readonly List<UIChoiceButton> playerSelectChoiceOptions = new();
         private readonly List<InventoryItemField> equipableItemChoiceOptions = new();
+        
+        // State
+        private bool isPartySolo = false;
         private CombatParticipant selectedCharacter;
         private Equipment selectedEquipment;
         private EquipLocation selectedEquipLocation = EquipLocation.None;
@@ -100,25 +103,38 @@ namespace Frankie.Inventory.UI
         #region Setup
         public void Setup(IStandardPlayerInputCaller standardPlayerInputCaller, PartyCombatConduit partyCombatConduit, List<CharacterSlide> setCharacterSlides)
         {
+            if (standardPlayerInputCaller == null || partyCombatConduit == null) { destroyQueued = true;  return; }
+            
             controller = standardPlayerInputCaller;
+            isPartySolo = partyCombatConduit.IsPartySolo();
+            
+            SetupPartySelection(partyCombatConduit);
+            
             characterSlides.Clear();
             foreach (CharacterSlide characterSlide in setCharacterSlides) { characterSlides.Add(characterSlide); }
+            
+            SetEquipmentBoxState(EquipmentBoxState.InCharacterSelection, true);
+            ShowCursorOnAnyInteraction(PlayerInputType.Execute);
+            if (isPartySolo) { Choose(null); }
+        }
 
+        private void SetupPartySelection(PartyCombatConduit partyCombatConduit)
+        {
             int choiceIndex = 0;
             foreach (CombatParticipant character in partyCombatConduit.GetPartyCombatParticipants())
             {
                 GameObject uiChoiceOptionObject = Instantiate(optionButtonPrefab, optionParent);
                 var uiChoiceOption = uiChoiceOptionObject.GetComponent<UIChoiceButton>();
                 uiChoiceOption.SetChoiceOrder(choiceIndex);
-                uiChoiceOption.SetText(character.GetCombatName());
                 uiChoiceOption.AddOnClickListener(delegate { ChooseCharacter(character, true); });
                 uiChoiceOption.AddOnHighlightListener(delegate { SoftChooseCharacter(character); });
+                uiChoiceOption.SetText(character.GetCombatName());
+                uiChoiceOption.SetValidColor(choiceIndex == 0);
+                uiChoiceOption.UseHighlightColor(true);
 
                 playerSelectChoiceOptions.Add(uiChoiceOption);
                 choiceIndex++;
             }
-            SetEquipmentBoxState(EquipmentBoxState.InCharacterSelection);
-            ShowCursorOnAnyInteraction(PlayerInputType.NavigateRight);
         }
 
         private void SetSelectedEquipment(Equipment equipment)
@@ -178,17 +194,17 @@ namespace Frankie.Inventory.UI
             }
             else
             {
-                ClearChoiceSelections();
+                ClearAllChoices();
                 ChooseCharacter(null);
             }
         }
 
-        protected override void ClearChoiceSelections()
+        private void ClearAllChoices()
         {
-            highlightedChoiceOption = null;
             foreach (UIChoiceButton dialogueChoiceOption in playerSelectChoiceOptions)
             {
                 dialogueChoiceOption.Highlight(false);
+                dialogueChoiceOption.SetValidColor(dialogueChoiceOption == highlightedChoiceOption);
             }
             foreach (InventoryItemField inventoryItemField in equipableItemChoiceOptions)
             {
@@ -198,10 +214,18 @@ namespace Frankie.Inventory.UI
             {
                 dialogueChoiceOption.Highlight(false);
             }
+            highlightedChoiceOption = null;
         }
 
-        private void SetEquipmentBoxState(EquipmentBoxState setEquipmentBoxState)
+        private void SetEquipmentBoxState(EquipmentBoxState setEquipmentBoxState, bool bypassSoloCheck = false)
         {
+            if (setEquipmentBoxState == EquipmentBoxState.InCharacterSelection && !bypassSoloCheck && isPartySolo)
+            {
+                // Skip character selection on solo character
+                destroyQueued = true;
+                return;
+            }
+            
             equipmentBoxState = setEquipmentBoxState;
             equipmentChangeMenu.SetActive(setEquipmentBoxState == EquipmentBoxState.InStatConfirmation);
             SetUpChoiceOptions();
@@ -252,7 +276,7 @@ namespace Frankie.Inventory.UI
         private void SoftChooseCharacter(CombatParticipant character)
         {
             ChooseCharacter(character, false, false);
-            SetEquipmentBoxState(EquipmentBoxState.InCharacterSelection);
+            SetEquipmentBoxState(EquipmentBoxState.InCharacterSelection, true);
         }
         #endregion
 

--- a/Assets/Scripts/UI/Inventory/Inventory/InventoryBox.cs
+++ b/Assets/Scripts/UI/Inventory/Inventory/InventoryBox.cs
@@ -44,14 +44,16 @@ namespace Frankie.Inventory.UI
         [Header("Include {0} for item name")] 
         [SerializeField][SimpleLocalizedString(LocalizationTableType.UI, true)] private LocalizedString localizedMessageDropItem;
         
-        // State
+        // State -- UI
         private InventoryBoxState inventoryBoxState = InventoryBoxState.InCharacterSelection;
         private readonly List<UIChoiceButton> playerSelectChoiceOptions = new();
-        private int selectedItemSlot = -1;
         protected readonly List<InventoryItemField> inventoryItemChoiceOptions = new();
+        
+        // State
+        private bool isPartySolo = false;
+        private int selectedItemSlot = -1;
         protected CombatParticipant selectedCharacter;
         protected Knapsack selectedKnapsack;
-        
         private BattleActionData battleActionData;
 
         // Cached References
@@ -101,10 +103,13 @@ namespace Frankie.Inventory.UI
         #endregion
 
         #region Setup
-        public void Setup(IStandardPlayerInputCaller standardPlayerInputCaller, PartyCombatConduit setPartyCombatConduit, List<CharacterSlide> setCharacterSlides)
+        public void Setup(IStandardPlayerInputCaller standardPlayerInputCaller, PartyCombatConduit setPartyCombatConduit, List<CharacterSlide> setCharacterSlides, bool useSoloAutoSelect = true)
         {
+            if (standardPlayerInputCaller == null || setPartyCombatConduit == null) { destroyQueued = true;  return; }
+            
             controller = standardPlayerInputCaller;
             partyCombatConduit = setPartyCombatConduit;
+            isPartySolo = partyCombatConduit.IsPartySolo();
             setCharacterSlides ??= new List<CharacterSlide>();
 
             if (standardPlayerInputCaller.GetType() == typeof(BattleController))
@@ -124,29 +129,29 @@ namespace Frankie.Inventory.UI
                 SubscribeCharacterSlides(true);
             }
 
+            SetupPartySelection();
+            SetInventoryBoxState(InventoryBoxState.InCharacterSelection, true);
+            ShowCursorOnAnyInteraction(PlayerInputType.Execute);
+            if (useSoloAutoSelect && isPartySolo) { Choose(null); }
+        }
+
+        private void SetupPartySelection()
+        {
             int choiceIndex = 0;
             foreach (CombatParticipant combatParticipant in partyCombatConduit.GetPartyCombatParticipants())
             {
                 GameObject uiChoiceOptionObject = Instantiate(optionButtonPrefab, optionParent);
                 var uiChoiceOption = uiChoiceOptionObject.GetComponent<UIChoiceButton>();
                 uiChoiceOption.SetChoiceOrder(choiceIndex);
-                uiChoiceOption.SetText(combatParticipant.GetCombatName());
                 uiChoiceOption.AddOnClickListener(delegate { ChooseCharacter(combatParticipant); });
                 uiChoiceOption.AddOnHighlightListener(delegate { SoftChooseCharacter(combatParticipant); });
-
-                if (choiceIndex == 0) { SoftChooseCharacter(combatParticipant); }
+                uiChoiceOption.SetText(combatParticipant.GetCombatName());
+                uiChoiceOption.SetValidColor(choiceIndex == 0);
+                uiChoiceOption.UseHighlightColor(true);
 
                 playerSelectChoiceOptions.Add(uiChoiceOption);
                 choiceIndex++;
             }
-            SetInventoryBoxState(InventoryBoxState.InCharacterSelection);
-            ShowCursorOnAnyInteraction(PlayerInputType.Execute);
-        }
-        
-        // For derivative Inventory Boxes without character slide hookup
-        public void Setup(IStandardPlayerInputCaller standardPlayerInputCaller, PartyCombatConduit setPartyCombatConduit)
-        {
-            Setup(standardPlayerInputCaller, setPartyCombatConduit, new List<CharacterSlide>());
         }
 
         // For derivative Inventory Boxes w/ single party member instantiation for specific application
@@ -210,29 +215,36 @@ namespace Frankie.Inventory.UI
 
         private void ReInitializeToCharacterSelection()
         {
-            ClearChoiceSelections();
+            ClearAllChoices();
             ChooseCharacter(null);
             ShowCursorOnAnyInteraction(PlayerInputType.Execute);
         }
 
-        protected override void ClearChoiceSelections()
+        private void ClearAllChoices()
         {
-            highlightedChoiceOption = null;
             foreach (UIChoiceButton dialogueChoiceOption in playerSelectChoiceOptions)
             {
                 dialogueChoiceOption.Highlight(false);
+                dialogueChoiceOption.SetValidColor(dialogueChoiceOption == highlightedChoiceOption);
             }
             foreach (InventoryItemField inventoryItemField in inventoryItemChoiceOptions)
             {
                 inventoryItemField.Highlight(false);
             }
+            highlightedChoiceOption = null;
         }
 
-        protected void SetInventoryBoxState(InventoryBoxState setInventoryBoxState)
+        protected void SetInventoryBoxState(InventoryBoxState setInventoryBoxState, bool bypassSoloCheck = false)
         {
+            if (setInventoryBoxState == InventoryBoxState.InCharacterSelection && !bypassSoloCheck && isPartySolo)
+            {
+                // Skip character selection on solo character
+                destroyQueued = true;
+                return;
+            }
+            
             inventoryBoxState = setInventoryBoxState;
             if (inventoryBoxState == InventoryBoxState.InCharacterSelection) { battleActionData = null; } // Reset battle action data on selected character changed
-
             SetUpChoiceOptions();
 
             uiBoxStateChanged?.Invoke(inventoryBoxState);
@@ -293,20 +305,14 @@ namespace Frankie.Inventory.UI
             battleActionData = new BattleActionData(selectedCharacter);
             SetInventoryBoxState(InventoryBoxState.InKnapsack);
 
-            if (IsChoiceAvailable())
-            {
-                if (initializeCursor) { MoveCursor(PlayerInputType.NavigateRight); }
-            }
-            else
-            {
-                SetInventoryBoxState(InventoryBoxState.InCharacterSelection);
-            }
+            if (initializeCursor && IsChoiceAvailable()) { MoveCursor(PlayerInputType.NavigateRight); }
+            if (!IsChoiceAvailable()) { SetInventoryBoxState(InventoryBoxState.InCharacterSelection, true); }
         }
 
         protected virtual void SoftChooseCharacter(CombatParticipant character)
         {
             ChooseCharacter(character, false);
-            SetInventoryBoxState(InventoryBoxState.InCharacterSelection);
+            SetInventoryBoxState(InventoryBoxState.InCharacterSelection, true);
         }
 
         protected void UpdateKnapsackView(CombatParticipant character)
@@ -328,11 +334,13 @@ namespace Frankie.Inventory.UI
         protected virtual void ChooseItem(int inventorySlot)
         {
             List<ChoiceActionPair> choiceActionPairs = GetChoiceActionPairs(inventorySlot);
-            if (choiceActionPairs.Count == 0) { return; }
-            else if (choiceActionPairs.Count == 1)
+            switch (choiceActionPairs.Count)
             {
-                choiceActionPairs[0].action?.Invoke();
-                return;
+                case 0:
+                    return;
+                case 1:
+                    choiceActionPairs[0].action?.Invoke();
+                    return;
             }
 
             SetInventoryBoxState(InventoryBoxState.InItemDetail);
@@ -576,11 +584,11 @@ namespace Frankie.Inventory.UI
         {
             if (!handleGlobalInput) { return true; } // Spoof:  Cannot accept input, so treat as if global input already handled
 
-            if (playerInputType == PlayerInputType.Option || playerInputType == PlayerInputType.Cancel)
+            if (playerInputType is PlayerInputType.Option or PlayerInputType.Cancel)
             {
                 if (inventoryBoxState == InventoryBoxState.InKnapsack)
                 {
-                    ClearChoiceSelections();
+                    ClearAllChoices();
                     SetInventoryBoxState(InventoryBoxState.InCharacterSelection);
                     return true;
                 }
@@ -595,20 +603,13 @@ namespace Frankie.Inventory.UI
             selectedItemSlot = -1;
             targetCharacterChanged?.Invoke(CombatParticipantType.Foe, null);
 
-            if (selectedCharacter == null || selectedKnapsack == null)
+            if (selectedCharacter == null || selectedKnapsack == null || selectedKnapsack.IsEmpty())
             {
                 ReInitializeToCharacterSelection();
             }
             else
             {
-                if (selectedKnapsack.IsEmpty())
-                {
-                    ReInitializeToCharacterSelection();
-                }
-                else
-                {
-                    SetInventoryBoxState(InventoryBoxState.InKnapsack);
-                }
+                SetInventoryBoxState(InventoryBoxState.InKnapsack);
             }
             handleGlobalInput = true;
         }

--- a/Assets/Scripts/UI/Inventory/Inventory/InventorySwapBox.cs
+++ b/Assets/Scripts/UI/Inventory/Inventory/InventorySwapBox.cs
@@ -40,7 +40,7 @@ namespace Frankie.Inventory.UI
         {
             swapItem = setSwapItem;
             swapSuccessAction = setSwapSuccessAction;
-            Setup(standardPlayerInputCaller, partyCombatConduit);
+            Setup(standardPlayerInputCaller, partyCombatConduit, null);
         }
         #endregion
 

--- a/Assets/Scripts/UI/Inventory/Shop/InventoryShopBox.cs
+++ b/Assets/Scripts/UI/Inventory/Shop/InventoryShopBox.cs
@@ -53,7 +53,7 @@ namespace Frankie.Inventory.UI
         {
             transactionType = ShopType.Buy;
             
-            base.Setup(standardPlayerInputCaller, partyCombatConduit);
+            base.Setup(standardPlayerInputCaller, partyCombatConduit, null, false);
             shopper = setShopper;
             shopBox = setShopBox;
             buyItem = setBuyItem;
@@ -65,7 +65,7 @@ namespace Frankie.Inventory.UI
         {
             transactionType = ShopType.Sell;
 
-            base.Setup(standardPlayerInputCaller, partyCombatConduit);
+            base.Setup(standardPlayerInputCaller, partyCombatConduit, null, false);
             playerStateMachine = setPlayerStateMachine;
             shopper = setShopper;
             messageForSale = setMessageForSale;

--- a/Assets/Scripts/UI/MainMenus/InWorld/OptionsMenu.cs
+++ b/Assets/Scripts/UI/MainMenus/InWorld/OptionsMenu.cs
@@ -37,7 +37,7 @@ namespace Frankie.Menu.UI
         [SerializeField] private UIChoiceToggle fullScreenWindowedToggle;
         [SerializeField] private Transform resolutionOptionsParent;
         [SerializeField] private TMP_Text languageHeaderField;
-        [SerializeField] private Transform languageOptionsParent;
+        [SerializeField] private UIChoiceContainer languageOptionsContainer;
         [SerializeField] private UIChoiceButton confirmOption;
         [SerializeField] private UIChoiceButton cancelOption;
         [Header("Default Sound Settings")]
@@ -220,19 +220,22 @@ namespace Frankie.Menu.UI
         private void InitializeLanguageSelection(ref int choiceIndex)
         {
             openingLocalizationType = LocalizationTool.GetCurrentLocalization();
+            Transform languageOptionsTransform = languageOptionsContainer.transform;
             
             foreach (SupportedLocalizationType supportedLocalizationType in Enum.GetValues(typeof(SupportedLocalizationType)))
             {
-                GameObject languageOption = Instantiate(optionButtonPrefab, languageOptionsParent);
+                GameObject languageOption = Instantiate(optionButtonPrefab, languageOptionsTransform);
                 if (languageOption.TryGetComponent(out UIChoiceButton languageChoiceButton))
                 {
                     languageChoiceButton.SetText(LocalizationTool.GetLocaleCode(supportedLocalizationType));
                     languageChoiceButton.AddOnClickListener(delegate { ConfirmLocalizationChange(supportedLocalizationType); });
-                    languageChoiceButton.SetChoiceOrder(choiceIndex);
-                    choiceIndex++;
+                    languageOptionsContainer.Add(languageChoiceButton);
                 }
                 else { Destroy(languageOption); } // incorrect input type
             }
+            
+            languageOptionsContainer.SetChoiceOrder(choiceIndex);
+            choiceIndex++;
         }
 
         private IEnumerator ResetOptions()

--- a/Assets/Scripts/UI/MainMenus/InWorld/OptionsMenu.cs
+++ b/Assets/Scripts/UI/MainMenus/InWorld/OptionsMenu.cs
@@ -1,14 +1,16 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using Frankie.Control;
 using UnityEngine;
 using UnityEngine.Localization;
 using UnityEngine.Localization.Tables;
 using TMPro;
-using Frankie.Sound;
 using Frankie.Rendering;
+using Frankie.Control;
+using Frankie.Speech.UI;
+using Frankie.Sound;
 using Frankie.Saving;
+using Frankie.Utils;
 using Frankie.Utils.Localization;
 using Frankie.Utils.UI;
 
@@ -27,6 +29,7 @@ namespace Frankie.Menu.UI
         [SerializeField][SimpleLocalizedString(LocalizationTableType.UI, true)] private LocalizedString localizedLanguageSelectText;
         [SerializeField][SimpleLocalizedString(LocalizationTableType.UI, true)] private LocalizedString localizedConfirmText;
         [SerializeField][SimpleLocalizedString(LocalizationTableType.UI, true)] private LocalizedString localizedCancelText;
+        [SerializeField][SimpleLocalizedString(LocalizationTableType.UI, true)] private LocalizedString localizedConfirmChangesText;
         [Header("Hookups")]
         [SerializeField] private TMP_Text optionsHeaderField;
         [SerializeField] private UIChoiceSlider masterVolumeSlider;
@@ -40,6 +43,8 @@ namespace Frankie.Menu.UI
         [SerializeField] private UIChoiceContainer languageOptionsContainer;
         [SerializeField] private UIChoiceButton confirmOption;
         [SerializeField] private UIChoiceButton cancelOption;
+        [Header("Prefabs")]
+        [SerializeField] private DialogueOptionBox dialogueOptionBoxPrefab;
         [Header("Default Sound Settings")]
         [SerializeField] private float defaultMasterVolume = 0.8f;
         [SerializeField] private float defaultBackgroundVolume = 0.5f;
@@ -52,6 +57,7 @@ namespace Frankie.Menu.UI
         private EscapeMenu escapeMenu;
 
         // State
+        private bool wasChangeMade = false;
         private float openingMasterVolume;
         private float openingBackgroundVolume;
         private float openingSoundEffectsVolume;
@@ -117,7 +123,8 @@ namespace Frankie.Menu.UI
                 localizedFullScreenWindowedText.TableEntryReference,
                 localizedLanguageSelectText.TableEntryReference,
                 localizedConfirmText.TableEntryReference,
-                localizedCancelText.TableEntryReference
+                localizedCancelText.TableEntryReference,
+                localizedConfirmChangesText.TableEntryReference,
             };
         }
         
@@ -146,7 +153,7 @@ namespace Frankie.Menu.UI
         {
             yield return ResetOptions(); 
             HandleClientExit();
-            Destroy(gameObject);
+            destroyQueued = true;
         }
         #endregion
 
@@ -244,12 +251,6 @@ namespace Frankie.Menu.UI
             yield return WaitForScreenChange(openingResolutionSetting);
         }
 
-        private void ForceResetOptions()
-        {
-            ResetNonDelayOptions();
-            ForceScreenChange(openingResolutionSetting);
-        }
-
         private void ResetNonDelayOptions()
         {
             masterVolumeSlider.SetSliderValue(openingMasterVolume);
@@ -257,13 +258,24 @@ namespace Frankie.Menu.UI
             soundEffectsVolumeSlider.SetSliderValue(openingSoundEffectsVolume);
             ConfirmLocalizationChange(openingLocalizationType);
         }
-        
-        private void SaveAndExit()
+
+        private void Save()
         {
             WriteScreenResolutionToPlayerPrefs();
             WriteVolumeToPlayerPrefs();
             PlayerPrefsController.SaveToDisk();
-            Destroy(gameObject);
+        }
+        
+        private void SaveAndExit()
+        {
+            Save();
+            destroyQueued = true;
+        }
+
+        private void ForceCancel()
+        {
+            ResetNonDelayOptions();
+            ForceScreenChange(openingResolutionSetting);
         }
 
         private void Cancel()
@@ -276,6 +288,7 @@ namespace Frankie.Menu.UI
         #region UIListenerMethods
         private void ConfirmSoundVolumes(bool playSoundEffect)
         {
+            wasChangeMade = true;
             float calculatedVolume = masterVolumeSlider.GetSliderValue() * backgroundVolumeSlider.GetSliderValue();
             backgroundMusic?.SetVolume(calculatedVolume);
 
@@ -286,6 +299,7 @@ namespace Frankie.Menu.UI
 
         private void ConfirmResolutionFullScreenWindowed(bool fullScreenWindowed)
         {
+            wasChangeMade = true;
             ResolutionSetting resolutionSetting;
 
             if (fullScreenWindowed)
@@ -303,6 +317,24 @@ namespace Frankie.Menu.UI
             }
             StartCoroutine(WaitForScreenChange(resolutionSetting));
         }
+        
+        private void ConfirmResolutionWindowed(ResolutionSetting resolutionSetting)
+        {
+            wasChangeMade = true;
+            fullScreenWindowedToggle.SetToggleValueSilently(false);
+            StartCoroutine(WaitForScreenChange(resolutionSetting));
+            WriteScreenResolutionToPlayerPrefs();
+        }
+        
+        private void ConfirmLocalizationChange(SupportedLocalizationType supportedLocalizationType)
+        {
+            wasChangeMade = true;
+            Debug.Log($"Current locale is {LocalizationTool.GetLocaleCode(LocalizationTool.GetCurrentLocalization())} - updating to {LocalizationTool.GetLocaleCode(supportedLocalizationType)}");
+            
+            LocalizationTool.SetLocale(supportedLocalizationType);
+            InitializeLocalization();
+            WriteLocalizationToPlayerPrefs(supportedLocalizationType);
+        }
 
         private IEnumerator WaitForScreenChange(ResolutionSetting resolutionSetting)
         {
@@ -315,27 +347,11 @@ namespace Frankie.Menu.UI
             DisplayResolutions.ForceScreenResolution(resolutionSetting);
             WriteScreenResolutionToPlayerPrefs();
         }
-
-        private void ConfirmResolutionWindowed(ResolutionSetting resolutionSetting)
-        {
-            fullScreenWindowedToggle.SetToggleValueSilently(false);
-            StartCoroutine(WaitForScreenChange(resolutionSetting));
-            WriteScreenResolutionToPlayerPrefs();
-        }
-
+        
         private void WriteLocalizationToPlayerPrefs(SupportedLocalizationType supportedLocalizationType)
         {
             string localeCode = LocalizationTool.GetLocaleCode(supportedLocalizationType);
             PlayerPrefsController.SetLanguageCode(localeCode);
-        }
-        
-        private void ConfirmLocalizationChange(SupportedLocalizationType supportedLocalizationType)
-        {
-            Debug.Log($"Current locale is {LocalizationTool.GetLocaleCode(LocalizationTool.GetCurrentLocalization())} - updating to {LocalizationTool.GetLocaleCode(supportedLocalizationType)}");
-            
-            LocalizationTool.SetLocale(supportedLocalizationType);
-            InitializeLocalization();
-            WriteLocalizationToPlayerPrefs(supportedLocalizationType);
         }
 
         private void WriteVolumeToPlayerPrefs()
@@ -344,14 +360,35 @@ namespace Frankie.Menu.UI
             PlayerPrefsController.SetBackgroundVolume(backgroundVolumeSlider.GetSliderValue());
             PlayerPrefsController.SetSoundEffectsVolume(soundEffectsVolumeSlider.GetSliderValue());
         }
+
+        private void SpawnConfirmationMenu()
+        {
+            var choiceActionPairs = new List<ChoiceActionPair>();
+            var equipActionPair = new ChoiceActionPair(localizedConfirmText.GetSafeLocalizedString(), Save);
+            choiceActionPairs.Add(equipActionPair);
+            var removeActionPair = new ChoiceActionPair(localizedCancelText.GetSafeLocalizedString(), ForceCancel);
+            choiceActionPairs.Add(removeActionPair);
+
+            DialogueOptionBox confirmChoiceOptionMenu = Instantiate(dialogueOptionBoxPrefab, transform.parent);
+            confirmChoiceOptionMenu.Setup(localizedConfirmChangesText.GetSafeLocalizedString());
+            confirmChoiceOptionMenu.OverrideChoiceOptions(choiceActionPairs);
+
+            PassControlToClose(confirmChoiceOptionMenu);
+        }
         #endregion
         
         #region InputHandling
         public override bool HandleGlobalInput(PlayerInputType playerInputType)
         {
+            if (!handleGlobalInput) { return true; } // Spoof:  Cannot accept input, so treat as if global input already handled
+            
             if (playerInputType is PlayerInputType.Cancel or PlayerInputType.Option or PlayerInputType.Escape)
             {
-                ForceResetOptions();
+                if (wasChangeMade)
+                {
+                    SpawnConfirmationMenu();
+                    return true;
+                }
             }
             return StandardHandleGlobalInput(playerInputType);
         }

--- a/Assets/Scripts/UI/Skills/AbilitiesBox.cs
+++ b/Assets/Scripts/UI/Skills/AbilitiesBox.cs
@@ -37,8 +37,8 @@ namespace Frankie.Combat.UI
         private AbilitiesBoxState abilitiesBoxState = AbilitiesBoxState.InCharacterSelection;
         private readonly List<UIChoiceButton> playerSelectChoiceOptions = new();
 
-        // State -- Objects
-        private PartyCombatConduit partyCombatConduit;
+        // State
+        private bool isPartySolo = false;
         private BattleActionData battleActionData;
 
         // Cached References
@@ -62,7 +62,6 @@ namespace Frankie.Combat.UI
         {
             return new List<TableEntryReference>
             {
-                localizedNoSkillSelectionText.TableEntryReference,
                 localizedStatLabel.TableEntryReference,
                 localizedAPCostLabel.TableEntryReference,
                 localizedMessageUseSkillInWorld.TableEntryReference,
@@ -72,12 +71,27 @@ namespace Frankie.Combat.UI
         }
         #endregion
         
-        #region PublicMethods
-        public void Setup(IStandardPlayerInputCaller standardPlayerInputCaller, PartyCombatConduit setPartyCombatConduit, List<CharacterSlide> setCharacterSlides)
+        #region Setup
+        public void Setup(IStandardPlayerInputCaller standardPlayerInputCaller, PartyCombatConduit partyCombatConduit, List<CharacterSlide> setCharacterSlides)
         {
+            if (standardPlayerInputCaller == null || partyCombatConduit == null) { destroyQueued = true;  return; }
+            
             controller = standardPlayerInputCaller;
-            partyCombatConduit = setPartyCombatConduit;
+            isPartySolo = partyCombatConduit.IsPartySolo();
 
+            SetupPartySelection(partyCombatConduit);
+            RefreshUI(CombatParticipantType.Friendly, partyBattleEntities);
+
+            characterSlides = setCharacterSlides;
+            SubscribeCharacterSlides(true);
+
+            SetAbilitiesBoxState(AbilitiesBoxState.InCharacterSelection, true);
+            ShowCursorOnAnyInteraction(PlayerInputType.Execute);
+            if (isPartySolo) { Choose(null); }
+        }
+
+        private void SetupPartySelection(PartyCombatConduit partyCombatConduit)
+        {
             int choiceIndex = 0;
             partyBattleEntities = new List<BattleEntity>();
             foreach (CombatParticipant combatParticipant in partyCombatConduit.GetPartyCombatParticipants())
@@ -85,21 +99,16 @@ namespace Frankie.Combat.UI
                 GameObject uiChoiceOptionObject = Instantiate(optionButtonPrefab, optionParent);
                 var uiChoiceOption = uiChoiceOptionObject.GetComponent<UIChoiceButton>();
                 uiChoiceOption.SetChoiceOrder(choiceIndex);
-                uiChoiceOption.SetText(combatParticipant.GetCombatName());
                 uiChoiceOption.AddOnClickListener(delegate { ChooseCharacter(combatParticipant); });
                 uiChoiceOption.AddOnHighlightListener(delegate { SoftChooseCharacter(combatParticipant); });
+                uiChoiceOption.SetText(combatParticipant.GetCombatName());
+                uiChoiceOption.SetValidColor(choiceIndex == 0);
+                uiChoiceOption.UseHighlightColor(true);
 
                 playerSelectChoiceOptions.Add(uiChoiceOption);
                 partyBattleEntities.Add(new BattleEntity(combatParticipant));
                 choiceIndex++;
             }
-            RefreshUI(CombatParticipantType.Friendly, partyBattleEntities);
-
-            characterSlides = setCharacterSlides;
-            SubscribeCharacterSlides(true);
-
-            SetAbilitiesBoxState(AbilitiesBoxState.InCharacterSelection);
-            ShowCursorOnAnyInteraction(PlayerInputType.Execute);
         }
 
         private void SubscribeCharacterSlides(bool enable)
@@ -193,7 +202,7 @@ namespace Frankie.Combat.UI
         private void SoftChooseCharacter(CombatParticipant character)
         {
             ChooseCharacter(character, false);
-            SetAbilitiesBoxState(AbilitiesBoxState.InCharacterSelection);
+            SetAbilitiesBoxState(AbilitiesBoxState.InCharacterSelection, true);
         }
 
         private bool ChooseSkill()
@@ -306,12 +315,17 @@ namespace Frankie.Combat.UI
         #endregion
 
         #region AbilitiesBehaviour
-        private void SetAbilitiesBoxState(AbilitiesBoxState setAbilitiesBoxState)
+        private void SetAbilitiesBoxState(AbilitiesBoxState setAbilitiesBoxState, bool bypassSoloCheck = false)
         {
             abilitiesBoxState = setAbilitiesBoxState;
             switch (abilitiesBoxState)
             {
                 case AbilitiesBoxState.InCharacterSelection:
+                    if (!bypassSoloCheck && isPartySolo)
+                    {
+                        destroyQueued = true;
+                        return;
+                    }
                     battleActionData = null; // Reset battle action data on selected character changed
                     ResetUI();
                     targetCharacterChanged?.Invoke(CombatParticipantType.Foe, null);
@@ -331,7 +345,7 @@ namespace Frankie.Combat.UI
 
         protected override void ResetUI()
         {
-            ResetUI(false);
+            ResetUI(true, false);
         }
         #endregion
 

--- a/Assets/Scripts/UI/Skills/AbilitiesBox.cs
+++ b/Assets/Scripts/UI/Skills/AbilitiesBox.cs
@@ -331,7 +331,7 @@ namespace Frankie.Combat.UI
 
         protected override void ResetUI()
         {
-            SetAllFields(defaultNoText);
+            ResetUI(false);
         }
         #endregion
 

--- a/Assets/Scripts/UI/Skills/SkillSelectionUI.cs
+++ b/Assets/Scripts/UI/Skills/SkillSelectionUI.cs
@@ -16,7 +16,6 @@ namespace Frankie.Combat.UI
         // Tunables
         [Header("Skill Selection Text")]
         [SerializeField] protected string defaultNoText = "--";
-        [SerializeField][SimpleLocalizedString(LocalizationTableType.UI, true)] protected LocalizedString localizedNoSkillSelectionText;
         [Header("Skill Selection Hookups")]
         [SerializeField] private TMP_Text selectedCharacterNameField;
         [SerializeField] protected TMP_Text skillField;
@@ -26,8 +25,8 @@ namespace Frankie.Combat.UI
         [SerializeField] private UIChoice downField;
 
         [Header("Configuration")] 
-        [SerializeField] private Color invalidSkillColor = Color.gray;
-        [SerializeField] private Color validSkillColor = Color.springGreen;
+        [SerializeField] private Color noSkillColor = Color.gray;
+        [SerializeField] private Color selectedSkillColor = Color.softYellow;
         
         // State
         private bool usingBattleController = false;
@@ -50,8 +49,8 @@ namespace Frankie.Combat.UI
         {
             if (skillField != null)
             {
-                skillField.color = invalidSkillColor;
-                skillField.SetText(localizedNoSkillSelectionText.GetSafeLocalizedString());
+                skillField.color = noSkillColor;
+                skillField.SetText(defaultNoText);
             }
         }
 
@@ -78,13 +77,7 @@ namespace Frankie.Combat.UI
         
         #region LocalizationMethods
         public LocalizationTableType localizationTableType { get; } = LocalizationTableType.UI;
-        public virtual List<TableEntryReference> GetLocalizationEntries()
-        {
-            return new List<TableEntryReference>
-            {
-                localizedNoSkillSelectionText.TableEntryReference,
-            };
-        }
+        public virtual List<TableEntryReference> GetLocalizationEntries() => new();
         #endregion
 
         #region InputHandlers
@@ -118,12 +111,13 @@ namespace Frankie.Combat.UI
 
         protected virtual void ResetUI()
         {
-            ResetUI(true);
+            ResetUI(true, true);
         }
         
-        protected void ResetUI(bool resetAlpha)
+        protected void ResetUI(bool resetAllFields, bool resetAlpha)
         {
-            ResetAllFields();
+            skillField.color = noSkillColor;
+            if (resetAllFields) { ResetAllFields(); }
             if (resetAlpha) { canvasGroup.alpha = 0; }
         }
         
@@ -202,7 +196,6 @@ namespace Frankie.Combat.UI
             leftField.SetText(defaultNoText);
             rightField.SetText(defaultNoText);
             downField.SetText(defaultNoText);
-            skillField.color = invalidSkillColor;
             skillField.SetText(defaultNoText);
         }
         
@@ -217,14 +210,14 @@ namespace Frankie.Combat.UI
             Skill activeSkill = skillHandler.GetActiveSkill();
             if (activeSkill != null)
             {
-                skillField.color = validSkillColor;
+                skillField.color = selectedSkillColor;
                 skillField.SetText(activeSkill.GetName());
                 if (battleController != null) { battleController.SetActiveBattleAction(activeSkill); }
                 OnUIBoxModified(UIBoxModifiedType.ItemSelected, true);
             }
             else
             {
-                skillField.color = invalidSkillColor;
+                skillField.color = noSkillColor;
                 skillField.SetText(defaultNoText);
             }
         }

--- a/Assets/Scripts/UI/Skills/SkillSelectionUI.cs
+++ b/Assets/Scripts/UI/Skills/SkillSelectionUI.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -26,6 +25,10 @@ namespace Frankie.Combat.UI
         [SerializeField] private UIChoice rightField;
         [SerializeField] private UIChoice downField;
 
+        [Header("Configuration")] 
+        [SerializeField] private Color invalidSkillColor = Color.gray;
+        [SerializeField] private Color validSkillColor = Color.springGreen;
+        
         // State
         private bool usingBattleController = false;
         protected CombatParticipant currentCombatParticipant;
@@ -44,8 +47,12 @@ namespace Frankie.Combat.UI
         
         #region UnityMethods
         protected virtual void Start()
-        { 
-            if (skillField != null) { skillField.SetText(localizedNoSkillSelectionText.GetSafeLocalizedString()); }
+        {
+            if (skillField != null)
+            {
+                skillField.color = invalidSkillColor;
+                skillField.SetText(localizedNoSkillSelectionText.GetSafeLocalizedString());
+            }
         }
 
         protected override void OnEnable()
@@ -111,8 +118,13 @@ namespace Frankie.Combat.UI
 
         protected virtual void ResetUI()
         {
-            SetAllFields(defaultNoText);
-            canvasGroup.alpha = 0;
+            ResetUI(true);
+        }
+        
+        protected void ResetUI(bool resetAlpha)
+        {
+            ResetAllFields();
+            if (resetAlpha) { canvasGroup.alpha = 0; }
         }
         
         protected void RefreshUI(CombatParticipantType combatParticipantType, IEnumerable<BattleEntity> battleEntities)
@@ -139,16 +151,6 @@ namespace Frankie.Combat.UI
             var skillHandler = currentCombatParticipant.GetComponent<SkillHandler>();
             skillHandler.ResetCurrentBranch();
             UpdateSkills(skillHandler);
-        }
-        
-        protected void SetAllFields(string text)
-        {
-            selectedCharacterNameField.SetText(text);
-            upField.SetText(text);
-            leftField.SetText(text);
-            rightField.SetText(text);
-            downField.SetText(text);
-            skillField.SetText(text);
         }
         
         protected bool SetBranchOrSkill(CombatParticipant combatParticipant, PlayerInputType input)
@@ -193,6 +195,17 @@ namespace Frankie.Combat.UI
         #endregion
 
         #region PrivateUtility
+        private void ResetAllFields()
+        {
+            selectedCharacterNameField.SetText(defaultNoText);
+            upField.SetText(defaultNoText);
+            leftField.SetText(defaultNoText);
+            rightField.SetText(defaultNoText);
+            downField.SetText(defaultNoText);
+            skillField.color = invalidSkillColor;
+            skillField.SetText(defaultNoText);
+        }
+        
         private void UpdateSkills(SkillHandler skillHandler)
         {
             skillHandler.GetPlayerSkillsForCurrentBranch(out Skill up, out Skill left, out Skill right, out Skill down);
@@ -203,12 +216,17 @@ namespace Frankie.Combat.UI
 
             Skill activeSkill = skillHandler.GetActiveSkill();
             if (activeSkill != null)
-            { 
+            {
+                skillField.color = validSkillColor;
                 skillField.SetText(activeSkill.GetName());
                 if (battleController != null) { battleController.SetActiveBattleAction(activeSkill); }
                 OnUIBoxModified(UIBoxModifiedType.ItemSelected, true);
-            } 
-            else { skillField.SetText(defaultNoText); }
+            }
+            else
+            {
+                skillField.color = invalidSkillColor;
+                skillField.SetText(defaultNoText);
+            }
         }
         #endregion
     }

--- a/Assets/Scripts/UI/UIBox/IUIMoveInterceptor.cs
+++ b/Assets/Scripts/UI/UIBox/IUIMoveInterceptor.cs
@@ -1,0 +1,9 @@
+using Frankie.Control;
+
+namespace Frankie.Utils.UI
+{
+    public interface IUIMoveInterceptor
+    {
+        public bool TryMove(PlayerInputType playerInputType);
+    }
+}

--- a/Assets/Scripts/UI/UIBox/IUIMoveInterceptor.cs.meta
+++ b/Assets/Scripts/UI/UIBox/IUIMoveInterceptor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 88e65a5a35b04a778d62bacd0073a1ed
+timeCreated: 1779908645

--- a/Assets/Scripts/UI/UIBox/UIBox.cs
+++ b/Assets/Scripts/UI/UIBox/UIBox.cs
@@ -18,7 +18,6 @@ namespace Frankie.Utils.UI
         [SerializeField] protected Transform optionParent;
         [SerializeField] protected GameObject optionButtonPrefab;
         [SerializeField] protected GameObject optionSliderPrefab;
-        [SerializeField] protected float sliderAdjustmentStep = 0.1f;
 
         // State -- Standard
         protected bool destroyQueued = false;
@@ -181,7 +180,10 @@ namespace Frankie.Utils.UI
         protected virtual void SetUpChoiceOptions()
         {
             if (clearVolatileOptionsOnEnable) { choiceOptions.Clear(); }
-            choiceOptions.AddRange(optionParent.gameObject.GetComponentsInChildren<UIChoice>().OrderBy(x => x.choiceOrder).ToList());
+
+            List<UIChoice> uiChoices = optionParent.gameObject.GetComponentsInChildren<UIChoice>().OrderBy(x => x.choiceOrder).ToList();
+            List<UIChoice> filteredUIChoices = FilterOutSubOptions(uiChoices);
+            choiceOptions.AddRange(filteredUIChoices);
 
             isChoiceAvailable = choiceOptions.Count > 0;
         }
@@ -212,6 +214,23 @@ namespace Frankie.Utils.UI
             uiChoiceOption.SetText(choiceText);
             choiceOptions.Add(uiChoiceOption);
             return uiChoiceOption;
+        }
+        
+        private List<UIChoice> FilterOutSubOptions(List<UIChoice> uiChoices)
+        {
+            List<UIChoice> filteredUIChoices = uiChoices.ToList();
+            
+            var subOptions = new List<UIChoice>();
+            foreach (UIChoice choice in filteredUIChoices)
+            {
+                if (choice is UIChoiceContainer uiChoiceContainer)
+                {
+                    subOptions.AddRange(uiChoiceContainer.GetSubOptions());
+                }
+            }
+
+            foreach (UIChoice choice in subOptions) { filteredUIChoices.Remove(choice); }
+            return filteredUIChoices;
         }
 
         protected virtual void ClearChoiceSelections()
@@ -273,9 +292,12 @@ namespace Frankie.Utils.UI
 
         protected virtual bool MoveCursor(PlayerInputType playerInputType)
         {
-            // Standard implementation
             if (!isChoiceAvailable || highlightedChoiceOption == null) { return false; }
 
+            // Special objects that require specialty input (sliders, etc.)
+            if (highlightedChoiceOption is IUIMoveInterceptor uiMoveInterceptor && uiMoveInterceptor.TryMove(playerInputType)) { return true; }
+            
+            // Standard choice handling
             int choiceIndex = choiceOptions.IndexOf(highlightedChoiceOption);
             bool validInput = MoveCursor(playerInputType, ref choiceIndex, choiceOptions.Count);
             if (validInput)
@@ -292,7 +314,11 @@ namespace Frankie.Utils.UI
         {
             // Standard implementation
             if (!isChoiceAvailable || highlightedChoiceOption == null) { return false; }
+
+            // Special objects that require specialty input (sliders, etc.)
+            if (highlightedChoiceOption is IUIMoveInterceptor uiMoveInterceptor && uiMoveInterceptor.TryMove(playerInputType)) { return true; }
             
+            // Standard choice handling
             int choiceIndex = choiceOptions.IndexOf(highlightedChoiceOption);
             bool validInput = MoveCursor2D(playerInputType, ref choiceIndex, choiceOptions.Count);
             if (validInput)
@@ -303,27 +329,6 @@ namespace Frankie.Utils.UI
                 return true;
             }
             return false;
-        }
-
-        private bool MoveSlider(PlayerInputType playerInputType)
-        {
-            // Standard implementation
-            if (!isChoiceAvailable || highlightedChoiceOption == null) { return false; }
-
-            var highlightedChoiceSlider = highlightedChoiceOption as UIChoiceSlider;
-            if (highlightedChoiceSlider == null) { return false; }
-
-            switch (playerInputType)
-            {
-                case PlayerInputType.NavigateLeft:
-                    highlightedChoiceSlider.AdjustValue(-sliderAdjustmentStep);
-                    return true;
-                case PlayerInputType.NavigateRight:
-                    highlightedChoiceSlider.AdjustValue(sliderAdjustmentStep);
-                    return true;
-                default:
-                    return false;
-            }
         }
         #endregion
 
@@ -417,7 +422,6 @@ namespace Frankie.Utils.UI
             if (!IsChoiceAvailable()) { return false; } // Childed objects can still accept input on no choices available
             if (ShowCursorOnAnyInteraction(playerInputType)) { return true; }
             if (PrepareChooseAction(playerInputType)) { return true; }
-            if (MoveSlider(playerInputType)) { return true; }
             if (MoveCursor(playerInputType)) { return true; }
 
             return false;

--- a/Assets/Scripts/UI/UIBox/UIBox.cs
+++ b/Assets/Scripts/UI/UIBox/UIBox.cs
@@ -347,12 +347,20 @@ namespace Frankie.Utils.UI
         
         public virtual bool HandleGlobalInput(PlayerInputType playerInputType)
         {
+            // NOTE:  When overriding, ensure to handle the bool:  handleGlobalInput
+            // To disable input when disabled, return true on !handleGlobalInput, or otherwise use HandleGlobalInputSpoofAndExit()
+            
             return StandardHandleGlobalInput(playerInputType);
         }
 
         protected void PassControl(UIBox delegateUIBox)
         {
             PassControl(this, new Action[] { () => EnableInput(true) }, delegateUIBox, controller);
+        }
+        
+        protected void PassControlToClose(UIBox delegateUIBox)
+        {
+            PassControl(this, new Action[] { () => EnableInput(true), () => destroyQueued = true }, delegateUIBox, controller);
         }
 
         protected void PassControl(IUIBoxCallbackReceiver callbackReceiver, IEnumerable<Action> actions, UIBox delegateUIBox, IStandardPlayerInputCaller standardPlayerInputCaller)

--- a/Assets/Scripts/UI/UIBox/UIBox.cs
+++ b/Assets/Scripts/UI/UIBox/UIBox.cs
@@ -279,7 +279,7 @@ namespace Frankie.Utils.UI
         protected bool ShowCursorOnAnyInteraction(PlayerInputType playerInputType)
         {
             if (!isChoiceAvailable || choiceOptions.Count == 0) { return false; }
-            if (playerInputType == PlayerInputType.DefaultNone || playerInputType == PlayerInputType.Cancel || playerInputType == PlayerInputType.Option) { return false; }
+            if (playerInputType is PlayerInputType.DefaultNone or PlayerInputType.Cancel or PlayerInputType.Option) { return false; }
 
             if (highlightedChoiceOption == null)
             {

--- a/Assets/Scripts/UI/UIBox/UIChoice.cs
+++ b/Assets/Scripts/UI/UIBox/UIChoice.cs
@@ -73,7 +73,7 @@ namespace Frankie.Utils.UI
             if (gameObject.activeSelf) { itemHighlighted.AddListener(unityAction); }
         }
 
-        public void Highlight(bool enable)
+        public virtual void Highlight(bool enable)
         {
             selectionMarker.SetActive(enable);
             if (enable && itemHighlighted != null) { itemHighlighted.Invoke(); }

--- a/Assets/Scripts/UI/UIBox/UIChoice.cs
+++ b/Assets/Scripts/UI/UIBox/UIChoice.cs
@@ -16,6 +16,7 @@ namespace Frankie.Utils.UI
 
         // State
         private readonly List<UnityAction> onHighlightExtraListeners = new();
+        private bool useHighlightColor = false;
 
         // Unity Events
         public UnityEvent itemHighlighted;
@@ -65,6 +66,11 @@ namespace Frankie.Utils.UI
             textField.color = enable ? validChoiceColor : invalidChoiceColor;
         }
 
+        public void UseHighlightColor(bool enable)
+        {
+            useHighlightColor = enable;
+        }
+
         public void AddOnHighlightListener(UnityAction unityAction)
         {
             if (unityAction == null) { return; }
@@ -76,6 +82,7 @@ namespace Frankie.Utils.UI
         public virtual void Highlight(bool enable)
         {
             selectionMarker.SetActive(enable);
+            if (useHighlightColor) { textField.color = enable ? validChoiceColor : invalidChoiceColor; }
             if (enable && itemHighlighted != null) { itemHighlighted.Invoke(); }
         }
         #endregion

--- a/Assets/Scripts/UI/UIBox/UIChoiceContainer.cs
+++ b/Assets/Scripts/UI/UIBox/UIChoiceContainer.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Linq;
+using Frankie.Control;
+using UnityEngine;
+
+namespace Frankie.Utils.UI
+{
+    public class UIChoiceContainer : UIChoice, IUIMoveInterceptor
+    {
+        // Tunables
+        [SerializeField] private bool isMoveHorizontal = true;
+
+        // State
+        private readonly List<UIChoice> uiChoices = new();
+        private UIChoice highlightedChoiceOption;
+        
+        #region PublicMethods
+        public void Add(UIChoice uiChoice)
+        {
+            uiChoices.Add(uiChoice);
+        }
+
+        public IList<UIChoice> GetSubOptions() => uiChoices.ToList();
+        
+        public bool TryMove(PlayerInputType playerInputType)
+        {
+            if (uiChoices.Count == 0) { return false; }
+            
+            switch (playerInputType)
+            {
+                case PlayerInputType.NavigateLeft when isMoveHorizontal:
+                case PlayerInputType.NavigateUp when !isMoveHorizontal:
+                    highlightedChoiceOption.Highlight(false);
+                    highlightedChoiceOption = GetNextChoice(false);
+                    highlightedChoiceOption.Highlight(true);
+                    return true;
+                case PlayerInputType.NavigateRight when isMoveHorizontal:
+                case PlayerInputType.NavigateDown when !isMoveHorizontal:
+                    highlightedChoiceOption.Highlight(false);
+                    highlightedChoiceOption = GetNextChoice(true);
+                    highlightedChoiceOption.Highlight(true);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public override void UseChoice()
+        {
+            if (highlightedChoiceOption == null) { return; }
+            highlightedChoiceOption.UseChoice();
+        }
+
+        public override void Highlight(bool enable)
+        {
+            if (uiChoices.Count == 0) { return; }
+
+            highlightedChoiceOption = null;
+            foreach (UIChoice uiChoice in uiChoices)
+            {
+                uiChoice.Highlight(false);
+            }
+
+            if (enable)
+            {
+                highlightedChoiceOption = uiChoices[0];
+                highlightedChoiceOption.Highlight(true);
+            }
+        }
+        #endregion
+        
+        #region PrivateMethods
+        private UIChoice GetNextChoice(bool isForward)
+        {
+            if (uiChoices.Count == 0) { return null; }
+            if (highlightedChoiceOption == null || !uiChoices.Contains(highlightedChoiceOption)) { return uiChoices.FirstOrDefault(); }
+            
+            int choiceIndex = uiChoices.IndexOf(highlightedChoiceOption);
+            int newChoiceIndex = isForward ? choiceIndex + 1 : choiceIndex - 1;
+            if (newChoiceIndex < 0) { newChoiceIndex = uiChoices.Count - 1; }
+            else if (newChoiceIndex >= uiChoices.Count) { newChoiceIndex = 0; }
+            
+            return uiChoices[newChoiceIndex];
+        }
+        #endregion
+    }
+}

--- a/Assets/Scripts/UI/UIBox/UIChoiceContainer.cs.meta
+++ b/Assets/Scripts/UI/UIBox/UIChoiceContainer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 42a6e35bbcdd4f2e886a079b0931493e
+timeCreated: 1779909034

--- a/Assets/Scripts/UI/UIBox/UIChoiceSlider.cs
+++ b/Assets/Scripts/UI/UIBox/UIChoiceSlider.cs
@@ -1,13 +1,15 @@
+using Frankie.Control;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.UI;
 
 namespace Frankie.Utils.UI
 {
-    public class UIChoiceSlider : UIChoice
+    public class UIChoiceSlider : UIChoice, IUIMoveInterceptor
     {
         // Tunables
         [SerializeField] private Slider slider;
+        [SerializeField] protected float sliderAdjustmentStep = 0.1f;
 
         // Methods
         #region UnityMethods
@@ -18,11 +20,26 @@ namespace Frankie.Utils.UI
         }
         #endregion
 
-        #region ClassMethods
+        #region VirtualInterfaceMethods
         public override void UseChoice()
         {
             // No implementation needed for slider
         }   
+        
+        public bool TryMove(PlayerInputType playerInputType)
+        {
+            switch (playerInputType)
+            {
+                case PlayerInputType.NavigateLeft:
+                    AdjustValue(-sliderAdjustmentStep);
+                    return true;
+                case PlayerInputType.NavigateRight:
+                    AdjustValue(sliderAdjustmentStep);
+                    return true;
+                default:
+                    return false;
+            }
+        }
         #endregion
 
         #region PublicMethods
@@ -33,16 +50,18 @@ namespace Frankie.Utils.UI
             slider.value = value;
         }
 
-        public void AdjustValue(float adjustment)
-        {
-            float updatedValue = slider.value + adjustment;
-            SetSliderValue(Mathf.Clamp(updatedValue, slider.minValue, slider.maxValue));
-        }
-
         public void AddOnValueChangeListener(UnityAction<float> unityAction)
         {
             if (unityAction == null) { return; }
             slider.onValueChanged.AddListener(unityAction);
+        }
+        #endregion
+        
+        #region PrivateMethods
+        private void AdjustValue(float adjustment)
+        {
+            float updatedValue = slider.value + adjustment;
+            SetSliderValue(Mathf.Clamp(updatedValue, slider.minValue, slider.maxValue));
         }
         #endregion
     }


### PR DESCRIPTION
## Changes Popup
*   When exiting settings without clicking OK or cancel (e.g. via tab/escape button), we currently revert the changes
*   Instead, we want a popup that asks to confirm changes yes/no, then exit out of menu

## Language Selection
*   Languages are currently in overarching UI item selection list, but they're in a horizontal div
*   We want to have some virtual selector for the horizontal div, which allows left/right selection of languages