### PR TITLE
CU-868k8fgpk :: UI Improvement:  Combat text should live in topmost layer

### DIFF
--- a/Assets/Game/CharacterObjects/NPCs/NonPlayableCharacter.prefab
+++ b/Assets/Game/CharacterObjects/NPCs/NonPlayableCharacter.prefab
@@ -599,6 +599,10 @@ MonoBehaviour:
     m_Bits: 8
   defaultCollisionsWhenAggravated: 1
   disableCollisionEventsWhenDead: 1
+  playerGoodLookCone: 90
+  npcGoodAwayCone: 150
+  npcBadLookCone: 60
+  playerBadAwayCone: 120
   collidedWithPlayer:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Game/UI/Combat/Battle Canvas.prefab
+++ b/Assets/Game/UI/Combat/Battle Canvas.prefab
@@ -1013,9 +1013,9 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1129675613400728901}
-  - {fileID: 4859047428861698195}
   - {fileID: 3363726339821156397}
+  - {fileID: 4859047428861698195}
+  - {fileID: 1129675613400728901}
   m_Father: {fileID: 2250791824682479779}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -1048,7 +1048,7 @@ MonoBehaviour:
   m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
-  m_ReverseArrangement: 1
+  m_ReverseArrangement: 0
 --- !u!114 &12796930514500083
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/ApartmentInterior.unity
+++ b/Assets/Scenes/ApartmentInterior.unity
@@ -27614,7 +27614,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 32cd30ad-e5ae-41a7-a2df-58c48eacde3c
-  backingListHashCheck: 44176627
+  backingListHashCheck: -785301844
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - b3f7fb4a-3295-4b70-95ac-59a716a281b2

--- a/Assets/Scenes/OfficeInterior.unity
+++ b/Assets/Scenes/OfficeInterior.unity
@@ -19420,7 +19420,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: e64e1b07-16e7-4f29-bad3-1f327b64370a
-  backingListHashCheck: -1223073351
+  backingListHashCheck: 1541213272
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 9cabe581-e4e8-4e07-9148-8190abc5e8e6
@@ -41435,7 +41435,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: c90051c8-6375-4741-a956-7d60c667db5d
-  backingListHashCheck: 602350159
+  backingListHashCheck: 1720335037
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - fd9ed298-c9f2-4c72-a440-4f02b469c9d7
@@ -58544,7 +58544,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: 2eaac1ac-4ad8-4a08-b529-89406a48f682
-  backingListHashCheck: -1381907248
+  backingListHashCheck: -1435246501
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 9cabe581-e4e8-4e07-9148-8190abc5e8e6
@@ -68011,7 +68011,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 2b6d94f5-ccce-434d-bd75-51ce1e4d7c8d
-  backingListHashCheck: 313438810
+  backingListHashCheck: -1070305898
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 61c08901-2fd9-403b-833e-f22949c8d448
@@ -70301,7 +70301,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 151435e9-c7b7-478f-a9cf-7aaad03e4487
-  backingListHashCheck: 1825468189
+  backingListHashCheck: 1074403999
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - a5a603ce-7ce9-41e5-982f-f3a64f2594e7
@@ -89710,7 +89710,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 34f6cd88-0481-4d84-b034-4d8db70384ad
-  backingListHashCheck: -837059007
+  backingListHashCheck: -1874919721
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - fd9ed298-c9f2-4c72-a440-4f02b469c9d7
@@ -131562,7 +131562,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: b12df4e9-c53d-47d3-9dfb-ddd969459176
-  backingListHashCheck: -2031780946
+  backingListHashCheck: 92710510
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 9cabe581-e4e8-4e07-9148-8190abc5e8e6
@@ -143176,7 +143176,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: c2a3aed0-a937-43f5-b032-5871ed446b2a
-  backingListHashCheck: 1028530989
+  backingListHashCheck: 2113638156
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - fd9ed298-c9f2-4c72-a440-4f02b469c9d7

--- a/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Exterior.unity
+++ b/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Exterior.unity
@@ -84283,7 +84283,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -40, y: -42, z: 0}
@@ -84322,7 +84322,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -37, y: -42, z: 0}
@@ -84452,7 +84452,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -27, y: -42, z: 0}
@@ -84465,7 +84465,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -26, y: -42, z: 0}
@@ -84738,7 +84738,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -5, y: -42, z: 0}
@@ -84855,7 +84855,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 1, y: -41, z: 0}
@@ -84907,7 +84907,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 5, y: -41, z: 0}
@@ -85011,7 +85011,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 12, y: -40, z: 0}
@@ -85024,7 +85024,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 13, y: -40, z: 0}
@@ -85037,7 +85037,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 14, y: -40, z: 0}
@@ -85115,7 +85115,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -47, y: -39, z: 0}
@@ -85128,7 +85128,7 @@ Tilemap:
       - {fileID: -272625038312284126, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -2987826598636523719, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1335908276603509373, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -48, y: -38, z: 0}
@@ -85167,7 +85167,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 22, y: -38, z: 0}
@@ -85323,7 +85323,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 33, y: -33, z: 0}
@@ -85518,7 +85518,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 48, y: -33, z: 0}
@@ -85557,7 +85557,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 51, y: -33, z: 0}
@@ -85700,7 +85700,7 @@ Tilemap:
       - {fileID: 466933687172928432, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1775959709872092871, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1127519975146461641, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 62, y: -23, z: 0}
@@ -85778,7 +85778,7 @@ Tilemap:
       - {fileID: -3560926823145120311, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 5054851352040530422, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5356723749812939064, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 61, y: -19, z: 0}
@@ -85791,7 +85791,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 68, y: -19, z: 0}
@@ -85817,7 +85817,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 70, y: -17, z: 0}
@@ -85843,7 +85843,7 @@ Tilemap:
       - {fileID: 466933687172928432, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1775959709872092871, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1127519975146461641, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 72, y: -14, z: 0}
@@ -85973,7 +85973,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 82, y: -9, z: 0}
@@ -86038,7 +86038,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 87, y: -9, z: 0}
@@ -86077,7 +86077,7 @@ Tilemap:
       - {fileID: 3874041234941493173, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -2655567598545868837, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1113992007117836429, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 90, y: -8, z: 0}
@@ -86129,7 +86129,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 94, y: -8, z: 0}
@@ -86220,7 +86220,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 101, y: -6, z: 0}
@@ -86246,7 +86246,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 103, y: -5, z: 0}
@@ -86337,7 +86337,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 110, y: -3, z: 0}
@@ -86350,7 +86350,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 111, y: -2, z: 0}
@@ -86402,7 +86402,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 115, y: 1, z: 0}
@@ -86428,7 +86428,7 @@ Tilemap:
       - {fileID: -3560926823145120311, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 5054851352040530422, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5356723749812939064, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 117, y: 3, z: 0}

--- a/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Interior.unity
+++ b/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Interior.unity
@@ -206929,7 +206929,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: c21cfe0b-b9ed-4c8e-b0bc-704a47b86215
-  backingListHashCheck: 1702090244
+  backingListHashCheck: -1450713169
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 5e78e614-19df-4719-8a5e-bc16139e86ee

--- a/Assets/Scripts/Control/Player/PlayerStateMachine/PlayerStates/CombatState.cs
+++ b/Assets/Scripts/Control/Player/PlayerStateMachine/PlayerStates/CombatState.cs
@@ -4,8 +4,7 @@ namespace Frankie.Control.PlayerStates
     {
         public void EnterCombat(IPlayerStateContext playerStateContext)
         {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
+            // Ignore - go to immunity post-combat, so cannot queue
         }
 
         public void EnterCutScene(IPlayerStateContext playerStateContext)

--- a/Assets/Scripts/Speech/Editor/DialogueConnectionsLayer.cs.meta
+++ b/Assets/Scripts/Speech/Editor/DialogueConnectionsLayer.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: aab343326f6db4493917b50023eb5b7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Speech/Editor/DialogueNodeView.cs.meta
+++ b/Assets/Scripts/Speech/Editor/DialogueNodeView.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 1fe0b776981e4401fbc158616562d743
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/UIBox/CursorMovementStyle.cs.meta
+++ b/Assets/Scripts/UI/UIBox/CursorMovementStyle.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 86ecdbbdf5674ddbb6c0e97291ad5e3c
-timeCreated: 1783447266
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils/DataStructuresExtensions/IStandardGraphNode.cs.meta
+++ b/Assets/Scripts/Utils/DataStructuresExtensions/IStandardGraphNode.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: aa48db3bfa10427194c5f0db2e504cdc
-timeCreated: 1783380592
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils/Editor/StandardCanvasPanManipulator.cs.meta
+++ b/Assets/Scripts/Utils/Editor/StandardCanvasPanManipulator.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: a0c1c7cc7ae6d40d89aba281966f2a7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils/Editor/StandardCanvasZoomManipulator.cs.meta
+++ b/Assets/Scripts/Utils/Editor/StandardCanvasZoomManipulator.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 2ced1a1166f5040f5a31394841e44aac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils/Editor/StandardNodeDragManipulator.cs.meta
+++ b/Assets/Scripts/Utils/Editor/StandardNodeDragManipulator.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: c53beb1e3bb42473fb2ba594e411c9df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Zones/Editor/ZoneEditor.meta
+++ b/Assets/Scripts/Zones/Editor/ZoneEditor.meta
@@ -1,3 +1,8 @@
 fileFormatVersion: 2
 guid: e596c39e7b754f7b827c3c9529680d9c
-timeCreated: 1783380143
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Zones/Editor/ZoneEditor/ZoneBackgroundLayer.cs.meta
+++ b/Assets/Scripts/Zones/Editor/ZoneEditor/ZoneBackgroundLayer.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 4d2813b8f5ca048338121d7b5505ecbd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Zones/Editor/ZoneEditor/ZoneEdgesLayer.cs.meta
+++ b/Assets/Scripts/Zones/Editor/ZoneEditor/ZoneEdgesLayer.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: b09fa8f932435479798e74ba96f30ab5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Zones/Editor/ZoneEditor/ZoneGraphView.cs.meta
+++ b/Assets/Scripts/Zones/Editor/ZoneEditor/ZoneGraphView.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: b74584eceadff47e78384e74e26ef153
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Zones/Editor/ZoneEditor/ZoneNodeView.cs.meta
+++ b/Assets/Scripts/Zones/Editor/ZoneEditor/ZoneNodeView.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 180d9896d470f4078820f5b7b35e0b0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is handled most easily by just re-arranging the order to the battle entities.  For some reason we had bottom row higher in the hierarchy and used flip order toggle on layout element.  Adjusting the hierarchy and unflipping this bit fixes everything.

Separately -- opportunistic bug fix on player state machine:  
Queuing and re-entering combat immediately without allowing a frame for past combat participant destruction causes issues.  Simplest fix here is just prevent queuing combat entry, since we always want player immunity post-combat anyway.