### PR TITLE
CU-868k9rg43 :: Save System:  More robust type checking and handling during deserialization

### DIFF
--- a/Assets/Game/Combat/SkillTrees/Characters/Frankie.asset
+++ b/Assets/Game/Combat/SkillTrees/Characters/Frankie.asset
@@ -70,8 +70,8 @@ MonoBehaviour:
   mappedFromBranch: 3
   rect:
     serializedVersion: 2
-    x: 375
-    y: 370
+    x: 409
+    y: 279
     width: 250
     height: 155
 --- !u!114 &2417977989957955819

--- a/Assets/Game/Speech/ConversantComponent.prefab
+++ b/Assets/Game/Speech/ConversantComponent.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 6564381309038757641}
   - component: {fileID: 6564381309038757639}
   - component: {fileID: 548448797238944362}
+  - component: {fileID: 7371511343337835833}
   m_Layer: 12
   m_Name: ConversantComponent
   m_TagString: Untagged
@@ -100,3 +101,17 @@ MonoBehaviour:
   onExitDialogue:
     m_PersistentCalls:
       m_Calls: []
+  saveDialogueCount: 1
+--- !u!114 &7371511343337835833
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6564381309038757640}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c708eed4772dbc14e95f0fb9be8bb48e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Frankie.Saving.SaveableEntity
+  uniqueIdentifier: 

--- a/Assets/Game/Speech/ConversantComponent.prefab
+++ b/Assets/Game/Speech/ConversantComponent.prefab
@@ -101,7 +101,7 @@ MonoBehaviour:
   onExitDialogue:
     m_PersistentCalls:
       m_Calls: []
-  saveDialogueCount: 1
+  saveDialogueCount: 0
 --- !u!114 &7371511343337835833
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/ApartmentInterior.unity
+++ b/Assets/Scenes/ApartmentInterior.unity
@@ -27614,7 +27614,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 32cd30ad-e5ae-41a7-a2df-58c48eacde3c
-  backingListHashCheck: 338105758
+  backingListHashCheck: -986483350
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - b3f7fb4a-3295-4b70-95ac-59a716a281b2

--- a/Assets/Scenes/ApartmentInterior.unity
+++ b/Assets/Scenes/ApartmentInterior.unity
@@ -26763,6 +26763,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 731387636}
     m_Modifications:
+    - target: {fileID: 2144923914519015686, guid: 838a6254f55229a41b966252d74ee1b4, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 6cca9dd7-f71e-4d5f-80a1-b9cb49ef83f0
+      objectReference: {fileID: 0}
     - target: {fileID: 5369551632885524120, guid: 838a6254f55229a41b966252d74ee1b4, type: 3}
       propertyPath: m_RootOrder
       value: -1
@@ -27614,7 +27618,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 32cd30ad-e5ae-41a7-a2df-58c48eacde3c
-  backingListHashCheck: 1194781633
+  backingListHashCheck: 1669328355
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - b3f7fb4a-3295-4b70-95ac-59a716a281b2
@@ -27928,6 +27932,10 @@ PrefabInstance:
     - target: {fileID: 6564381309038757641, guid: 3ba2ab0c1cea63442a5dec585154a263, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7371511343337835833, guid: 3ba2ab0c1cea63442a5dec585154a263, type: 3}
+      propertyPath: uniqueIdentifier
+      value: d4932c5c-ec0a-4a6c-afcb-8044c3b00957
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -28316,6 +28324,10 @@ PrefabInstance:
     - target: {fileID: 6564381309038757641, guid: 3ba2ab0c1cea63442a5dec585154a263, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7371511343337835833, guid: 3ba2ab0c1cea63442a5dec585154a263, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 21b0535c-27b9-4e10-8c38-586849f82120
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/ApartmentInterior.unity
+++ b/Assets/Scenes/ApartmentInterior.unity
@@ -27614,7 +27614,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 32cd30ad-e5ae-41a7-a2df-58c48eacde3c
-  backingListHashCheck: -986483350
+  backingListHashCheck: 1194781633
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - b3f7fb4a-3295-4b70-95ac-59a716a281b2

--- a/Assets/Scenes/OfficeExterior.unity
+++ b/Assets/Scenes/OfficeExterior.unity
@@ -689,6 +689,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1614018449}
     m_Modifications:
+    - target: {fileID: 886243705027859069, guid: bfa8cb7cfccd24c40943b48ac4aa332d, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 68b0206a-6e6b-45cb-8bf2-4153283f2f7f
+      objectReference: {fileID: 0}
     - target: {fileID: 3386044621720643084, guid: bfa8cb7cfccd24c40943b48ac4aa332d, type: 3}
       propertyPath: m_Name
       value: HelpfulVole (1)
@@ -4236,6 +4240,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7988917558390847417, guid: 30c6f3f30a3216e41bbc8a6ac45c57e0, type: 3}
+      propertyPath: uniqueIdentifier
+      value: fd1e943c-d1c3-466b-9dc4-523df3a0ef8f
+      objectReference: {fileID: 0}
     - target: {fileID: 8654748381369162415, guid: 30c6f3f30a3216e41bbc8a6ac45c57e0, type: 3}
       propertyPath: backingHandlerGUID
       value: 96aae745-c9e9-4ff4-9362-a9108256566c
@@ -6423,6 +6431,10 @@ PrefabInstance:
     - target: {fileID: 2819359886622569768, guid: a87622f06df9ac54e90516e57e833835, type: 3}
       propertyPath: uniqueIdentifier
       value: a879aa96-6518-4c0c-a6b3-3c68ab82b9cd
+      objectReference: {fileID: 0}
+    - target: {fileID: 4918713745143814974, guid: a87622f06df9ac54e90516e57e833835, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 33f06de1-c5b9-4f93-88e6-bbadc13980f5
       objectReference: {fileID: 0}
     - target: {fileID: 5946803103528515112, guid: a87622f06df9ac54e90516e57e833835, type: 3}
       propertyPath: backingHandlerGUID
@@ -10677,6 +10689,10 @@ PrefabInstance:
     - target: {fileID: 4891157998954341668, guid: 04f5506a3c6980342b86a87faa9be780, type: 3}
       propertyPath: backingListHashCheck
       value: -1964433073
+      objectReference: {fileID: 0}
+    - target: {fileID: 6135419693849823282, guid: 04f5506a3c6980342b86a87faa9be780, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 20435852-7d80-4949-8fe7-cc12187d1dfc
       objectReference: {fileID: 0}
     - target: {fileID: 7525764789776728579, guid: 04f5506a3c6980342b86a87faa9be780, type: 3}
       propertyPath: m_IsActive
@@ -15867,6 +15883,10 @@ PrefabInstance:
       propertyPath: backingListHashCheck
       value: 1508308105
       objectReference: {fileID: 0}
+    - target: {fileID: 3604880868275781410, guid: b755f1c23f46b2a4fba44873acc4a9d8, type: 3}
+      propertyPath: uniqueIdentifier
+      value: cce59876-4f00-4a15-9610-b30523d16913
+      objectReference: {fileID: 0}
     - target: {fileID: 4613052352910209963, guid: b755f1c23f46b2a4fba44873acc4a9d8, type: 3}
       propertyPath: patrolPath
       value: 
@@ -17213,6 +17233,10 @@ PrefabInstance:
       propertyPath: lootEntries.Array.data[0].inventoryItem
       value: 
       objectReference: {fileID: 11400000, guid: d4605b3b7a5ce394180efaf721695e04, type: 2}
+    - target: {fileID: 3712612268587877196, guid: 68fc39e15d6aac647a45438aaa59a974, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 97b2b1ab-f862-45de-ae0a-d6e7fb4045a4
+      objectReference: {fileID: 0}
     - target: {fileID: 5829753337919008090, guid: 68fc39e15d6aac647a45438aaa59a974, type: 3}
       propertyPath: uniqueIdentifier
       value: b3f18071-90fd-4e0e-a8be-2c9484b459fb
@@ -18218,6 +18242,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1584137188}
     m_Modifications:
+    - target: {fileID: 886243705027859069, guid: bfa8cb7cfccd24c40943b48ac4aa332d, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 24527847-c223-498c-bec3-ee00d6efb095
+      objectReference: {fileID: 0}
     - target: {fileID: 3386044621720643084, guid: bfa8cb7cfccd24c40943b48ac4aa332d, type: 3}
       propertyPath: m_Name
       value: HelpfulVole
@@ -59036,6 +59064,10 @@ PrefabInstance:
       propertyPath: dialogue
       value: 
       objectReference: {fileID: 11400000, guid: b946db02fd5d3594983f0dc1b23d67c4, type: 2}
+    - target: {fileID: 5634723788117127374, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
+      propertyPath: uniqueIdentifier
+      value: a75ef5a4-5056-4d27-b614-49aeaba473e7
+      objectReference: {fileID: 0}
     - target: {fileID: 6410608619545107928, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
       propertyPath: backingHandlerGUID
       value: a0569edf-4c1c-4c1f-87c5-f562d85531f9

--- a/Assets/Scenes/OfficeInterior.unity
+++ b/Assets/Scenes/OfficeInterior.unity
@@ -19233,6 +19233,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 951111758}
     m_Modifications:
+    - target: {fileID: 887123758075453905, guid: cf37675f8add8ca4dadb8829377d5cb7, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 2abea6e6-e06f-4023-a92b-e141eb97a3be
+      objectReference: {fileID: 0}
     - target: {fileID: 1340039601518036884, guid: cf37675f8add8ca4dadb8829377d5cb7, type: 3}
       propertyPath: checkInteraction.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
@@ -19420,7 +19424,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: e64e1b07-16e7-4f29-bad3-1f327b64370a
-  backingListHashCheck: 1933447273
+  backingListHashCheck: 2133449097
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 9cabe581-e4e8-4e07-9148-8190abc5e8e6
@@ -19753,6 +19757,10 @@ PrefabInstance:
     - target: {fileID: 2648853192062587444, guid: b755f1c23f46b2a4fba44873acc4a9d8, type: 3}
       propertyPath: <handlerGUID>k__BackingField
       value: a76c7d83-8230-41e7-b9d1-e303336d6213
+      objectReference: {fileID: 0}
+    - target: {fileID: 3604880868275781410, guid: b755f1c23f46b2a4fba44873acc4a9d8, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 098b2cf4-fe72-45c5-926d-ad810a0be974
       objectReference: {fileID: 0}
     - target: {fileID: 4613052352910209963, guid: b755f1c23f46b2a4fba44873acc4a9d8, type: 3}
       propertyPath: patrolPath
@@ -41435,7 +41443,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: c90051c8-6375-4741-a956-7d60c667db5d
-  backingListHashCheck: -175100052
+  backingListHashCheck: 1277730758
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - fd9ed298-c9f2-4c72-a440-4f02b469c9d7
@@ -41631,6 +41639,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1124876882}
     m_Modifications:
+    - target: {fileID: 887123758075453905, guid: cf37675f8add8ca4dadb8829377d5cb7, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 08430615-1fbd-445d-a962-8fe6875c86a4
+      objectReference: {fileID: 0}
     - target: {fileID: 1340039601518036884, guid: cf37675f8add8ca4dadb8829377d5cb7, type: 3}
       propertyPath: checkInteraction.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
@@ -58544,7 +58556,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: 2eaac1ac-4ad8-4a08-b529-89406a48f682
-  backingListHashCheck: 1950962437
+  backingListHashCheck: -22284854
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 9cabe581-e4e8-4e07-9148-8190abc5e8e6
@@ -59288,6 +59300,10 @@ PrefabInstance:
       propertyPath: <handlerGUID>k__BackingField
       value: 851b4afc-ef25-471f-a9ae-0b24d99b1eb4
       objectReference: {fileID: 0}
+    - target: {fileID: 8283798206989294276, guid: 3e8aa571b6fd5cd4c83d58166eabf29c, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 78709b36-17cf-4fed-9b43-591ece456cef
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -59550,6 +59566,10 @@ PrefabInstance:
     - target: {fileID: 4891157998954341668, guid: 04f5506a3c6980342b86a87faa9be780, type: 3}
       propertyPath: <handlerGUID>k__BackingField
       value: beb705e5-14be-410a-8cf9-38c99107db8a
+      objectReference: {fileID: 0}
+    - target: {fileID: 6135419693849823282, guid: 04f5506a3c6980342b86a87faa9be780, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 8ed2ad6d-ce27-4142-ad77-9416103f1617
       objectReference: {fileID: 0}
     - target: {fileID: 7525764789776728579, guid: 04f5506a3c6980342b86a87faa9be780, type: 3}
       propertyPath: m_IsActive
@@ -59915,6 +59935,10 @@ PrefabInstance:
       propertyPath: patrolPath
       value: 
       objectReference: {fileID: 50796131}
+    - target: {fileID: 4918713745143814974, guid: a87622f06df9ac54e90516e57e833835, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 54d3eb7b-f8c2-4c2a-b81f-9d6f1305f3ba
+      objectReference: {fileID: 0}
     - target: {fileID: 5946803103528515112, guid: a87622f06df9ac54e90516e57e833835, type: 3}
       propertyPath: backingHandlerGUID
       value: c2934bc4-d12a-406f-a69b-9bb1be4d9a69
@@ -60141,6 +60165,10 @@ PrefabInstance:
     - target: {fileID: 6564381309038757641, guid: 3ba2ab0c1cea63442a5dec585154a263, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7371511343337835833, guid: 3ba2ab0c1cea63442a5dec585154a263, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 5b5d9b70-cc8c-4541-b181-4db8eea7f7bf
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 6564381309038757639, guid: 3ba2ab0c1cea63442a5dec585154a263, type: 3}
@@ -67807,6 +67835,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7371511343337835833, guid: 3ba2ab0c1cea63442a5dec585154a263, type: 3}
+      propertyPath: uniqueIdentifier
+      value: aa07525a-ea04-4854-b846-a1c29a7a7656
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -68011,7 +68043,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 2b6d94f5-ccce-434d-bd75-51ce1e4d7c8d
-  backingListHashCheck: -2053256031
+  backingListHashCheck: -1139278371
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 61c08901-2fd9-403b-833e-f22949c8d448
@@ -69343,6 +69375,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7988917558390847417, guid: 30c6f3f30a3216e41bbc8a6ac45c57e0, type: 3}
+      propertyPath: uniqueIdentifier
+      value: d8d6a048-cc67-4205-bf54-994939aa4f77
+      objectReference: {fileID: 0}
     - target: {fileID: 8654748381369162415, guid: 30c6f3f30a3216e41bbc8a6ac45c57e0, type: 3}
       propertyPath: backingHandlerGUID
       value: c76acf0d-30a8-48af-aa8f-17fe6a3a8938
@@ -69461,6 +69497,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1245758512}
     m_Modifications:
+    - target: {fileID: 886243705027859069, guid: bfa8cb7cfccd24c40943b48ac4aa332d, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 3456a24f-84b1-4b0b-b177-3bf479890b71
+      objectReference: {fileID: 0}
     - target: {fileID: 3386044621720643084, guid: bfa8cb7cfccd24c40943b48ac4aa332d, type: 3}
       propertyPath: m_Name
       value: HelpfulVole (1)
@@ -70301,7 +70341,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 151435e9-c7b7-478f-a9cf-7aaad03e4487
-  backingListHashCheck: 675078681
+  backingListHashCheck: -1742113896
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - a5a603ce-7ce9-41e5-982f-f3a64f2594e7
@@ -87974,6 +88014,10 @@ PrefabInstance:
       propertyPath: <handlerGUID>k__BackingField
       value: 13e74046-3620-47ed-8070-ef5daa41ad36
       objectReference: {fileID: 0}
+    - target: {fileID: 6662974831736673085, guid: e5b2dd736debcc24a83caba30bd0c03f, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 94e18bea-fc20-4a41-bca2-a4b459104e60
+      objectReference: {fileID: 0}
     - target: {fileID: 6999197217183127820, guid: e5b2dd736debcc24a83caba30bd0c03f, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -88230,6 +88274,10 @@ PrefabInstance:
       propertyPath: dialogue
       value: 
       objectReference: {fileID: 11400000, guid: 4fc9c2cb1cbf0ae419935bd0f91f81b2, type: 2}
+    - target: {fileID: 5634723788117127374, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 4621c135-67f7-4492-93de-06f1f3aa41d0
+      objectReference: {fileID: 0}
     - target: {fileID: 6410608619545107928, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
       propertyPath: backingHandlerGUID
       value: 20c88ea3-46b1-4c12-9688-cab8e4d4f1b6
@@ -89347,6 +89395,10 @@ PrefabInstance:
       propertyPath: <handlerGUID>k__BackingField
       value: 2546de7c-99dd-440f-b6fe-de64b958732a
       objectReference: {fileID: 0}
+    - target: {fileID: 8283798206989294276, guid: 85e454fc5088ab64cbf94d522f93ecc7, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 86c3b1e0-d14f-4fa1-857b-718313a3d2ce
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -89710,7 +89762,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 34f6cd88-0481-4d84-b034-4d8db70384ad
-  backingListHashCheck: -427690554
+  backingListHashCheck: 1731453381
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - fd9ed298-c9f2-4c72-a440-4f02b469c9d7
@@ -131014,6 +131066,10 @@ PrefabInstance:
       propertyPath: dialogue
       value: 
       objectReference: {fileID: 11400000, guid: f0bc019e72b5e8145a2949e6c12be816, type: 2}
+    - target: {fileID: 5634723788117127374, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
+      propertyPath: uniqueIdentifier
+      value: f1687c03-1d2e-46c2-bf72-812ff4399dfd
+      objectReference: {fileID: 0}
     - target: {fileID: 6410608619545107928, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
       propertyPath: backingHandlerGUID
       value: d371a645-a394-4708-941d-54d65d49fd4b
@@ -131449,6 +131505,10 @@ PrefabInstance:
       propertyPath: uniqueIdentifier
       value: 212b55d8-264e-433f-ad91-b5a7e74907b2
       objectReference: {fileID: 0}
+    - target: {fileID: 4918713745143814974, guid: a87622f06df9ac54e90516e57e833835, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 14ed4b43-5e75-4ecf-a9ff-ac606cba4365
+      objectReference: {fileID: 0}
     - target: {fileID: 5946803103528515112, guid: a87622f06df9ac54e90516e57e833835, type: 3}
       propertyPath: backingHandlerGUID
       value: 0e52423c-13da-4be8-bb0f-aad49ffba4aa
@@ -131562,7 +131622,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: b12df4e9-c53d-47d3-9dfb-ddd969459176
-  backingListHashCheck: -733533660
+  backingListHashCheck: 32394272
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 9cabe581-e4e8-4e07-9148-8190abc5e8e6
@@ -143176,7 +143236,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: c2a3aed0-a937-43f5-b032-5871ed446b2a
-  backingListHashCheck: -1860656614
+  backingListHashCheck: -1623574136
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - fd9ed298-c9f2-4c72-a440-4f02b469c9d7

--- a/Assets/Scenes/OfficeInterior.unity
+++ b/Assets/Scenes/OfficeInterior.unity
@@ -19420,7 +19420,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: e64e1b07-16e7-4f29-bad3-1f327b64370a
-  backingListHashCheck: 213043330
+  backingListHashCheck: 1933447273
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 9cabe581-e4e8-4e07-9148-8190abc5e8e6
@@ -41435,7 +41435,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: c90051c8-6375-4741-a956-7d60c667db5d
-  backingListHashCheck: -2073164087
+  backingListHashCheck: -175100052
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - fd9ed298-c9f2-4c72-a440-4f02b469c9d7
@@ -58544,7 +58544,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: 2eaac1ac-4ad8-4a08-b529-89406a48f682
-  backingListHashCheck: -1238184104
+  backingListHashCheck: 1950962437
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 9cabe581-e4e8-4e07-9148-8190abc5e8e6
@@ -68011,7 +68011,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 2b6d94f5-ccce-434d-bd75-51ce1e4d7c8d
-  backingListHashCheck: -337643425
+  backingListHashCheck: -2053256031
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 61c08901-2fd9-403b-833e-f22949c8d448
@@ -70301,7 +70301,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 151435e9-c7b7-478f-a9cf-7aaad03e4487
-  backingListHashCheck: 404168343
+  backingListHashCheck: 675078681
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - a5a603ce-7ce9-41e5-982f-f3a64f2594e7
@@ -89710,7 +89710,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 34f6cd88-0481-4d84-b034-4d8db70384ad
-  backingListHashCheck: 498167748
+  backingListHashCheck: -427690554
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - fd9ed298-c9f2-4c72-a440-4f02b469c9d7
@@ -131562,7 +131562,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: b12df4e9-c53d-47d3-9dfb-ddd969459176
-  backingListHashCheck: -1308500427
+  backingListHashCheck: -733533660
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 9cabe581-e4e8-4e07-9148-8190abc5e8e6
@@ -143176,7 +143176,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: c2a3aed0-a937-43f5-b032-5871ed446b2a
-  backingListHashCheck: -395149318
+  backingListHashCheck: -1860656614
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - fd9ed298-c9f2-4c72-a440-4f02b469c9d7

--- a/Assets/Scenes/OfficeInterior.unity
+++ b/Assets/Scenes/OfficeInterior.unity
@@ -19420,7 +19420,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: e64e1b07-16e7-4f29-bad3-1f327b64370a
-  backingListHashCheck: 921114632
+  backingListHashCheck: 213043330
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 9cabe581-e4e8-4e07-9148-8190abc5e8e6
@@ -41435,7 +41435,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: c90051c8-6375-4741-a956-7d60c667db5d
-  backingListHashCheck: 404858966
+  backingListHashCheck: -2073164087
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - fd9ed298-c9f2-4c72-a440-4f02b469c9d7
@@ -58544,7 +58544,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: 2eaac1ac-4ad8-4a08-b529-89406a48f682
-  backingListHashCheck: 1068551641
+  backingListHashCheck: -1238184104
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 9cabe581-e4e8-4e07-9148-8190abc5e8e6
@@ -68011,7 +68011,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 2b6d94f5-ccce-434d-bd75-51ce1e4d7c8d
-  backingListHashCheck: -1385326343
+  backingListHashCheck: -337643425
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 61c08901-2fd9-403b-833e-f22949c8d448
@@ -70301,7 +70301,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 151435e9-c7b7-478f-a9cf-7aaad03e4487
-  backingListHashCheck: 978516822
+  backingListHashCheck: 404168343
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - a5a603ce-7ce9-41e5-982f-f3a64f2594e7
@@ -89710,7 +89710,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backingHandlerGUID: 34f6cd88-0481-4d84-b034-4d8db70384ad
-  backingListHashCheck: -1087757279
+  backingListHashCheck: 498167748
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - fd9ed298-c9f2-4c72-a440-4f02b469c9d7
@@ -131562,7 +131562,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: b12df4e9-c53d-47d3-9dfb-ddd969459176
-  backingListHashCheck: 1394469889
+  backingListHashCheck: -1308500427
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 9cabe581-e4e8-4e07-9148-8190abc5e8e6
@@ -143176,7 +143176,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: c2a3aed0-a937-43f5-b032-5871ed446b2a
-  backingListHashCheck: -1921529547
+  backingListHashCheck: -395149318
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - fd9ed298-c9f2-4c72-a440-4f02b469c9d7

--- a/Assets/Scenes/PortaBank.unity
+++ b/Assets/Scenes/PortaBank.unity
@@ -143,6 +143,10 @@ PrefabInstance:
       propertyPath: overrideDefaultInteractionDistance
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 5634723788117127374, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 7740ca2b-25e1-46c0-ad01-f0129e716896
+      objectReference: {fileID: 0}
     - target: {fileID: 6410608619545107928, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
       propertyPath: backingHandlerGUID
       value: 13b5e116-b0ce-4f94-835c-b411d8a44d86

--- a/Assets/Scenes/PrimInterior.unity
+++ b/Assets/Scenes/PrimInterior.unity
@@ -443,6 +443,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Lexi (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 7265634569038392830, guid: 4d87ee9942258394096a0e9a40993801, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 2c642ed2-47a9-4f68-8f8b-f290aec7a919
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -11611,6 +11615,10 @@ PrefabInstance:
       propertyPath: dialogue
       value: 
       objectReference: {fileID: 11400000, guid: 487be0659bd7544538fdebe784f7fc25, type: 2}
+    - target: {fileID: 6801303911162038568, guid: b58385ad4bc92c945972c4f80f2be1b3, type: 3}
+      propertyPath: uniqueIdentifier
+      value: f2e80620-79c9-4456-989f-046eab02ebec
+      objectReference: {fileID: 0}
     - target: {fileID: 8994288306620644697, guid: b58385ad4bc92c945972c4f80f2be1b3, type: 3}
       propertyPath: m_Name
       value: Ron (1)
@@ -30622,6 +30630,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Estelle (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 8675942148148766946, guid: 6355dd8a17e27464598b4200738afc8c, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 907495b9-3d63-4df9-8e40-c6eee5944bd5
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -40504,6 +40516,10 @@ PrefabInstance:
       propertyPath: dialogue
       value: 
       objectReference: {fileID: 11400000, guid: 3b30ce2e0dcca4b8ba4018ed51351e58, type: 2}
+    - target: {fileID: 5640729318857076631, guid: ca76e9bd1168a0a45b163bd3c60f51ea, type: 3}
+      propertyPath: uniqueIdentifier
+      value: ec297c98-b063-4d13-891f-8d9e4e064cb9
+      objectReference: {fileID: 0}
     - target: {fileID: 7851693060512553957, guid: ca76e9bd1168a0a45b163bd3c60f51ea, type: 3}
       propertyPath: m_LocalPosition.x
       value: 7.9424696

--- a/Assets/Scenes/_Debug/TEST_BattleRoyale.unity
+++ b/Assets/Scenes/_Debug/TEST_BattleRoyale.unity
@@ -77965,11 +77965,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9140000498525693428, guid: 9bf5874c37e0a404a9bd916129a14959, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -5.43
+      value: -0.76
       objectReference: {fileID: 0}
     - target: {fileID: 9140000498525693428, guid: 9bf5874c37e0a404a9bd916129a14959, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -6.19
+      value: -5.69
       objectReference: {fileID: 0}
     - target: {fileID: 9140000498525693428, guid: 9bf5874c37e0a404a9bd916129a14959, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Scenes/_Debug/TEST_BattleRoyale.unity
+++ b/Assets/Scenes/_Debug/TEST_BattleRoyale.unity
@@ -39679,6 +39679,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8962689956275295713, guid: 7acdda3804013364ca749486116b3e18, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 9a7d0479-d14f-4537-83ef-ef3f671e6de7
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Exterior.unity
+++ b/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Exterior.unity
@@ -84287,7 +84287,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -40, y: -42, z: 0}
@@ -84404,7 +84404,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -31, y: -42, z: 0}
@@ -84443,7 +84443,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -28, y: -42, z: 0}
@@ -84508,7 +84508,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -23, y: -42, z: 0}
@@ -84521,7 +84521,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -22, y: -42, z: 0}
@@ -84547,7 +84547,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -20, y: -42, z: 0}
@@ -84560,7 +84560,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -19, y: -42, z: 0}
@@ -84716,7 +84716,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -7, y: -42, z: 0}
@@ -84820,7 +84820,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -43, y: -41, z: 0}
@@ -84872,7 +84872,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 2, y: -41, z: 0}
@@ -84924,7 +84924,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 6, y: -41, z: 0}
@@ -84937,7 +84937,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 7, y: -41, z: 0}
@@ -85041,7 +85041,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 14, y: -40, z: 0}
@@ -85054,7 +85054,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 15, y: -40, z: 0}
@@ -85132,7 +85132,7 @@ Tilemap:
       - {fileID: -272625038312284126, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -2987826598636523719, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1335908276603509373, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -48, y: -38, z: 0}
@@ -85158,7 +85158,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 21, y: -38, z: 0}
@@ -85366,7 +85366,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 36, y: -33, z: 0}
@@ -85418,7 +85418,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 40, y: -33, z: 0}
@@ -85431,7 +85431,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 41, y: -33, z: 0}
@@ -85444,7 +85444,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 42, y: -33, z: 0}
@@ -85652,7 +85652,7 @@ Tilemap:
       - {fileID: 466933687172928432, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1775959709872092871, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1127519975146461641, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 58, y: -28, z: 0}
@@ -85769,7 +85769,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 67, y: -20, z: 0}
@@ -85834,7 +85834,7 @@ Tilemap:
       - {fileID: 3874041234941493173, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -2655567598545868837, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1113992007117836429, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 71, y: -15, z: 0}
@@ -85899,7 +85899,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 76, y: -11, z: 0}
@@ -86146,7 +86146,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 95, y: -8, z: 0}
@@ -86263,7 +86263,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 104, y: -5, z: 0}
@@ -86302,7 +86302,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 107, y: -4, z: 0}
@@ -86315,7 +86315,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 108, y: -3, z: 0}
@@ -86354,7 +86354,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 111, y: -2, z: 0}

--- a/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Exterior.unity
+++ b/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Exterior.unity
@@ -68975,6 +68975,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 717057658}
     m_Modifications:
+    - target: {fileID: 886243705027859069, guid: bfa8cb7cfccd24c40943b48ac4aa332d, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 8ef82e8a-2665-4c65-bbb9-992f1304cd2e
+      objectReference: {fileID: 0}
     - target: {fileID: 3386044621720643084, guid: bfa8cb7cfccd24c40943b48ac4aa332d, type: 3}
       propertyPath: m_Name
       value: HelpfulVole
@@ -84309,7 +84313,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -38, y: -42, z: 0}
@@ -84400,7 +84404,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -31, y: -42, z: 0}
@@ -84556,7 +84560,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -19, y: -42, z: 0}
@@ -84712,7 +84716,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -7, y: -42, z: 0}
@@ -84816,7 +84820,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -43, y: -41, z: 0}
@@ -84868,7 +84872,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 2, y: -41, z: 0}
@@ -84920,7 +84924,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 6, y: -41, z: 0}
@@ -84933,7 +84937,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 7, y: -41, z: 0}
@@ -85024,7 +85028,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 13, y: -40, z: 0}
@@ -85050,7 +85054,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 15, y: -40, z: 0}
@@ -85128,7 +85132,7 @@ Tilemap:
       - {fileID: -272625038312284126, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -2987826598636523719, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1335908276603509373, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -48, y: -38, z: 0}
@@ -85258,7 +85262,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 29, y: -37, z: 0}
@@ -85349,7 +85353,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 35, y: -33, z: 0}
@@ -85362,7 +85366,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 36, y: -33, z: 0}
@@ -85414,7 +85418,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 40, y: -33, z: 0}
@@ -85427,7 +85431,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 41, y: -33, z: 0}
@@ -85752,7 +85756,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 66, y: -21, z: 0}
@@ -85765,7 +85769,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 67, y: -20, z: 0}
@@ -85830,7 +85834,7 @@ Tilemap:
       - {fileID: 3874041234941493173, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -2655567598545868837, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1113992007117836429, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 71, y: -15, z: 0}
@@ -86090,7 +86094,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 91, y: -8, z: 0}
@@ -86116,7 +86120,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 93, y: -8, z: 0}
@@ -86142,7 +86146,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 95, y: -8, z: 0}
@@ -86246,7 +86250,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 103, y: -5, z: 0}
@@ -86350,7 +86354,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 111, y: -2, z: 0}
@@ -229067,6 +229071,10 @@ PrefabInstance:
       propertyPath: dialogue
       value: 
       objectReference: {fileID: 11400000, guid: ed380599497e1466a8c4e57e1cd836e7, type: 2}
+    - target: {fileID: 1853097853933569969, guid: 6355dd8a17e27464598b4200738afc8c, type: 3}
+      propertyPath: saveDialogueCount
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1947115918370817780, guid: 6355dd8a17e27464598b4200738afc8c, type: 3}
       propertyPath: uniqueIdentifier
       value: b24023f0-633b-432e-9b63-89336a2df947
@@ -229114,6 +229122,10 @@ PrefabInstance:
     - target: {fileID: 6545444647813274771, guid: 6355dd8a17e27464598b4200738afc8c, type: 3}
       propertyPath: m_Name
       value: Estelle (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8675942148148766946, guid: 6355dd8a17e27464598b4200738afc8c, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 309ce9f8-d383-4beb-aadc-d7df0531ffb3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Exterior.unity
+++ b/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Exterior.unity
@@ -84287,7 +84287,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -40, y: -42, z: 0}
@@ -84300,7 +84300,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -39, y: -42, z: 0}
@@ -84404,7 +84404,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -31, y: -42, z: 0}
@@ -84456,7 +84456,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -27, y: -42, z: 0}
@@ -84508,7 +84508,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -23, y: -42, z: 0}
@@ -84521,7 +84521,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -22, y: -42, z: 0}
@@ -84534,7 +84534,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -21, y: -42, z: 0}
@@ -84547,7 +84547,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -20, y: -42, z: 0}
@@ -84859,7 +84859,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 1, y: -41, z: 0}
@@ -85041,7 +85041,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 14, y: -40, z: 0}
@@ -85119,7 +85119,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -47, y: -39, z: 0}
@@ -85158,7 +85158,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 21, y: -38, z: 0}
@@ -85379,7 +85379,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 37, y: -33, z: 0}
@@ -85444,7 +85444,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 42, y: -33, z: 0}
@@ -85522,7 +85522,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 48, y: -33, z: 0}
@@ -85535,7 +85535,7 @@ Tilemap:
       - {fileID: 369703860382564206, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4739526959144531198, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -5460716150843776568, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 49, y: -33, z: 0}
@@ -85652,7 +85652,7 @@ Tilemap:
       - {fileID: 466933687172928432, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1775959709872092871, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1127519975146461641, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 58, y: -28, z: 0}
@@ -85899,7 +85899,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 76, y: -11, z: 0}
@@ -86263,7 +86263,7 @@ Tilemap:
       - {fileID: -9127494257955121339, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1064193029922757897, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -1690165687374623767, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 104, y: -5, z: 0}
@@ -86315,7 +86315,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5000001
+      m_AnimationSpeed: 1.5
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 108, y: -3, z: 0}
@@ -86406,7 +86406,7 @@ Tilemap:
       - {fileID: 7121123139229542265, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: 4767268207902280266, guid: a4830863e3a724f71aa567088257520c, type: 3}
       - {fileID: -4506875625572309658, guid: a4830863e3a724f71aa567088257520c, type: 3}
-      m_AnimationSpeed: 1.5
+      m_AnimationSpeed: 1.5000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 115, y: 1, z: 0}

--- a/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Interior.unity
+++ b/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Interior.unity
@@ -206929,7 +206929,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: c21cfe0b-b9ed-4c8e-b0bc-704a47b86215
-  backingListHashCheck: 1584577195
+  backingListHashCheck: 1977033417
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 5e78e614-19df-4719-8a5e-bc16139e86ee

--- a/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Interior.unity
+++ b/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Interior.unity
@@ -317,6 +317,10 @@ PrefabInstance:
       propertyPath: backingListHashCheck
       value: 53867758
       objectReference: {fileID: 0}
+    - target: {fileID: 8532826403865279038, guid: d03dd34cf927349baabdfaa7bd5642d9, type: 3}
+      propertyPath: uniqueIdentifier
+      value: d7ff7abf-2113-48f2-a4c7-e514872ffe04
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1773,6 +1777,10 @@ PrefabInstance:
       propertyPath: lookDirectionOnDwell.y
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4920282112908134339, guid: 6253a2d4b9cf44b45b95c47141d9f8d0, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 3dc598e0-3b32-4ace-874c-dd27e510d108
+      objectReference: {fileID: 0}
     - target: {fileID: 5948652017889585877, guid: 6253a2d4b9cf44b45b95c47141d9f8d0, type: 3}
       propertyPath: backingHandlerGUID
       value: 13238276-d4ba-4bef-812e-634a7ab06bde
@@ -2256,6 +2264,10 @@ PrefabInstance:
       propertyPath: dialogue
       value: 
       objectReference: {fileID: 11400000, guid: c2e89af0af2c94e538b417ff4f395c9d, type: 2}
+    - target: {fileID: 6801303911162038568, guid: b58385ad4bc92c945972c4f80f2be1b3, type: 3}
+      propertyPath: uniqueIdentifier
+      value: d9a857b2-a9b4-4510-b195-f76ec7474610
+      objectReference: {fileID: 0}
     - target: {fileID: 8994288306620644697, guid: b58385ad4bc92c945972c4f80f2be1b3, type: 3}
       propertyPath: m_Name
       value: Ron (1)
@@ -2485,6 +2497,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7299112966667274147, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
+      propertyPath: uniqueIdentifier
+      value: f9f6dfdd-19d0-45c1-bbf7-4ece01976e28
+      objectReference: {fileID: 0}
     - target: {fileID: 8326638319341906613, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
       propertyPath: backingHandlerGUID
       value: 4210eb19-1dde-4e9c-89b8-8f49a468db9f
@@ -2698,6 +2714,10 @@ PrefabInstance:
     - target: {fileID: 6020141406999707016, guid: 30c6f3f30a3216e41bbc8a6ac45c57e0, type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7988917558390847417, guid: 30c6f3f30a3216e41bbc8a6ac45c57e0, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 25a719a0-2517-4183-a888-910486e51bc3
       objectReference: {fileID: 0}
     - target: {fileID: 8654748381369162415, guid: 30c6f3f30a3216e41bbc8a6ac45c57e0, type: 3}
       propertyPath: backingHandlerGUID
@@ -3636,6 +3656,10 @@ PrefabInstance:
     - target: {fileID: 6349556598447574418, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7299112966667274147, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 618ec032-590f-4c2d-b532-c51e1984a3a6
       objectReference: {fileID: 0}
     - target: {fileID: 8326638319341906613, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
       propertyPath: backingHandlerGUID
@@ -4914,6 +4938,10 @@ PrefabInstance:
     - target: {fileID: 5103150634027777102, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
       propertyPath: backingListHashCheck
       value: 1989599768
+      objectReference: {fileID: 0}
+    - target: {fileID: 5771232680623067480, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
+      propertyPath: uniqueIdentifier
+      value: ac583939-a99b-478f-9f43-06e1aac2132c
       objectReference: {fileID: 0}
     - target: {fileID: 7872865046525369193, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
       propertyPath: m_IsActive
@@ -6558,6 +6586,10 @@ PrefabInstance:
     - target: {fileID: 6564381309038757641, guid: 3ba2ab0c1cea63442a5dec585154a263, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7371511343337835833, guid: 3ba2ab0c1cea63442a5dec585154a263, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 6cb1cb77-a899-47f1-b80a-f2c19d169432
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -101753,6 +101785,10 @@ PrefabInstance:
       propertyPath: lookDirectionOnDwell.y
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4920282112908134339, guid: 6253a2d4b9cf44b45b95c47141d9f8d0, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 7f53b75b-c5c2-4807-a3c4-29e33cf126e9
+      objectReference: {fileID: 0}
     - target: {fileID: 5948652017889585877, guid: 6253a2d4b9cf44b45b95c47141d9f8d0, type: 3}
       propertyPath: backingHandlerGUID
       value: 14ecfebf-0f21-478e-952c-b7e1f77b4e46
@@ -114352,6 +114388,10 @@ PrefabInstance:
       propertyPath: backingListHashCheck
       value: -753788447
       objectReference: {fileID: 0}
+    - target: {fileID: 5771232680623067480, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
+      propertyPath: uniqueIdentifier
+      value: a1395e99-93fa-4144-9ce1-21bebc5c528b
+      objectReference: {fileID: 0}
     - target: {fileID: 7872865046525369193, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -114555,6 +114595,10 @@ PrefabInstance:
     - target: {fileID: 5103150634027777102, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
       propertyPath: backingListHashCheck
       value: -459264510
+      objectReference: {fileID: 0}
+    - target: {fileID: 5771232680623067480, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
+      propertyPath: uniqueIdentifier
+      value: f0382260-8992-4276-b6af-2fd5ad8a7d00
       objectReference: {fileID: 0}
     - target: {fileID: 7872865046525369193, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
       propertyPath: m_IsActive
@@ -125668,6 +125712,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7299112966667274147, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 3afda22b-8c47-41ae-8018-65743b9c7808
+      objectReference: {fileID: 0}
     - target: {fileID: 8326638319341906613, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
       propertyPath: backingHandlerGUID
       value: 8fcf71eb-eafc-44fa-ac4e-98aac3ff5ac2
@@ -125938,6 +125986,10 @@ PrefabInstance:
     - target: {fileID: 6349556598447574418, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7299112966667274147, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
+      propertyPath: uniqueIdentifier
+      value: e8a71695-2f5e-4b0f-a7ad-c9db483d4f96
       objectReference: {fileID: 0}
     - target: {fileID: 8326638319341906613, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
       propertyPath: backingHandlerGUID
@@ -126252,6 +126304,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7299112966667274147, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
+      propertyPath: uniqueIdentifier
+      value: add184df-dbed-4d71-b8c8-a8c20beac1f6
+      objectReference: {fileID: 0}
     - target: {fileID: 8326638319341906613, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
       propertyPath: backingHandlerGUID
       value: 1bd7e29c-b99d-4303-96a9-f16b6b59f467
@@ -126441,6 +126497,10 @@ PrefabInstance:
     - target: {fileID: 5103150634027777102, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
       propertyPath: backingListHashCheck
       value: 1898753577
+      objectReference: {fileID: 0}
+    - target: {fileID: 5771232680623067480, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 914514dc-f997-4526-916d-030e61b08bc6
       objectReference: {fileID: 0}
     - target: {fileID: 7872865046525369193, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
       propertyPath: m_IsActive
@@ -140875,6 +140935,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7299112966667274147, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 3897bd3b-4993-4ccb-9dc9-c0c2e6817c0a
+      objectReference: {fileID: 0}
     - target: {fileID: 8326638319341906613, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
       propertyPath: backingHandlerGUID
       value: 464fc607-03d4-4f4e-ba4a-5867f345c9e5
@@ -140912,6 +140976,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 389645416}
     m_Modifications:
+    - target: {fileID: 65248422666655179, guid: b40c8a2d41c557a49a83d28cd7fce1d1, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 156b8a8a-fd1e-4b6d-a02e-0ab8211bc6a4
+      objectReference: {fileID: 0}
     - target: {fileID: 2474441335414202809, guid: b40c8a2d41c557a49a83d28cd7fce1d1, type: 3}
       propertyPath: m_LocalPosition.x
       value: 9.355
@@ -168827,6 +168895,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7299112966667274147, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
+      propertyPath: uniqueIdentifier
+      value: cfb75bb9-90b0-4eea-9638-c9680b9aa077
+      objectReference: {fileID: 0}
     - target: {fileID: 8326638319341906613, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
       propertyPath: backingHandlerGUID
       value: 721d9d82-9eed-49da-902a-41818bd53b8a
@@ -169082,6 +169154,10 @@ PrefabInstance:
     - target: {fileID: 3912392375922248522, guid: 6253a2d4b9cf44b45b95c47141d9f8d0, type: 3}
       propertyPath: lookDirectionOnDwell.y
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4920282112908134339, guid: 6253a2d4b9cf44b45b95c47141d9f8d0, type: 3}
+      propertyPath: uniqueIdentifier
+      value: d4b7ca49-a05d-4e7b-b3d6-9c65f1a64eba
       objectReference: {fileID: 0}
     - target: {fileID: 5948652017889585877, guid: 6253a2d4b9cf44b45b95c47141d9f8d0, type: 3}
       propertyPath: backingHandlerGUID
@@ -191804,6 +191880,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7299112966667274147, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
+      propertyPath: uniqueIdentifier
+      value: b85dfbd5-aa88-4c28-9268-51bdb0fb4c1e
+      objectReference: {fileID: 0}
     - target: {fileID: 8326638319341906613, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
       propertyPath: backingHandlerGUID
       value: 3ce7b090-94a3-4345-9eb8-6cf8bae86bb9
@@ -193079,6 +193159,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7299112966667274147, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 98e8e48c-eefa-4ff6-b118-33a3ba19d7d8
+      objectReference: {fileID: 0}
     - target: {fileID: 8326638319341906613, guid: a54e983b6ddf64fe4a03236cfe391a6a, type: 3}
       propertyPath: backingHandlerGUID
       value: 668d8c3c-c812-4ba6-b996-f51b3dba6aa0
@@ -193505,6 +193589,10 @@ PrefabInstance:
       propertyPath: lookDirectionOnDwell.y
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4920282112908134339, guid: 6253a2d4b9cf44b45b95c47141d9f8d0, type: 3}
+      propertyPath: uniqueIdentifier
+      value: a381181e-2d55-40d0-8400-52a710bda128
+      objectReference: {fileID: 0}
     - target: {fileID: 5948652017889585877, guid: 6253a2d4b9cf44b45b95c47141d9f8d0, type: 3}
       propertyPath: backingHandlerGUID
       value: 835da903-7a90-4e10-b329-01cf6b979412
@@ -193898,6 +193986,10 @@ PrefabInstance:
     - target: {fileID: 5103150634027777102, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
       propertyPath: backingListHashCheck
       value: 1672765796
+      objectReference: {fileID: 0}
+    - target: {fileID: 5771232680623067480, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 7def4a1c-5e11-417e-9ef0-1ac2eb0d1b67
       objectReference: {fileID: 0}
     - target: {fileID: 7872865046525369193, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
       propertyPath: m_IsActive
@@ -206796,6 +206888,10 @@ PrefabInstance:
       propertyPath: lootEntries.Array.data[0].inventoryItem
       value: 
       objectReference: {fileID: 11400000, guid: acec52c8feb0f43c2bc042fd53e19922, type: 2}
+    - target: {fileID: 6135419693849823282, guid: 04f5506a3c6980342b86a87faa9be780, type: 3}
+      propertyPath: uniqueIdentifier
+      value: d8787e16-913d-4ac4-803a-c919d6328d4c
+      objectReference: {fileID: 0}
     - target: {fileID: 7525764789776728579, guid: 04f5506a3c6980342b86a87faa9be780, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -206929,7 +207025,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Frankie.Quests.QuestHandler
   backingHandlerGUID: c21cfe0b-b9ed-4c8e-b0bc-704a47b86215
-  backingListHashCheck: 1977033417
+  backingListHashCheck: -1041021548
   backingHasGameStateModifiers: 1
   backingGameStateModifierGUIDs:
   - 5e78e614-19df-4719-8a5e-bc16139e86ee
@@ -218050,6 +218146,10 @@ PrefabInstance:
       propertyPath: backingListHashCheck
       value: 1254760173
       objectReference: {fileID: 0}
+    - target: {fileID: 5771232680623067480, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 38af06d5-4702-465c-a581-5734d1401956
+      objectReference: {fileID: 0}
     - target: {fileID: 7872865046525369193, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -218685,6 +218785,10 @@ PrefabInstance:
       propertyPath: backingListHashCheck
       value: -292372559
       objectReference: {fileID: 0}
+    - target: {fileID: 5771232680623067480, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
+      propertyPath: uniqueIdentifier
+      value: dd38c0c7-21bc-4223-ad75-5afbad800147
+      objectReference: {fileID: 0}
     - target: {fileID: 7872865046525369193, guid: 9db400b1c758c4a2ba866c8e88a18672, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -218861,6 +218965,10 @@ PrefabInstance:
       propertyPath: dialogue
       value: 
       objectReference: {fileID: 11400000, guid: 0ca958db9d5924815b5e1700f9506cb7, type: 2}
+    - target: {fileID: 5346735842002146046, guid: 9946002348b53f64d8ad1d52b7fd88c3, type: 3}
+      propertyPath: uniqueIdentifier
+      value: ce20d7d9-b647-4b45-adea-362b33c2bdc1
+      objectReference: {fileID: 0}
     - target: {fileID: 7530686785756096140, guid: 9946002348b53f64d8ad1d52b7fd88c3, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.729606
@@ -233180,6 +233288,10 @@ PrefabInstance:
       propertyPath: lookDirectionOnDwell.y
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4920282112908134339, guid: 6253a2d4b9cf44b45b95c47141d9f8d0, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 4efcbea2-b4ea-4f80-a335-b3479273402d
+      objectReference: {fileID: 0}
     - target: {fileID: 5948652017889585877, guid: 6253a2d4b9cf44b45b95c47141d9f8d0, type: 3}
       propertyPath: backingHandlerGUID
       value: 790f54e5-a251-4b81-912c-b01f05372d2b
@@ -244767,6 +244879,10 @@ PrefabInstance:
       propertyPath: dialogue
       value: 
       objectReference: {fileID: 11400000, guid: 92460ba292c8b423cad161735d477972, type: 2}
+    - target: {fileID: 5640729318857076631, guid: ca76e9bd1168a0a45b163bd3c60f51ea, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 70fc6a5a-61a1-430c-8859-d16c4c9385f5
+      objectReference: {fileID: 0}
     - target: {fileID: 7851693060512553957, guid: ca76e9bd1168a0a45b163bd3c60f51ea, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0.84637237

--- a/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Portabank.unity
+++ b/Assets/Scenes/_Demos/Forest_Level1to20/Demo_Forest1to20-Portabank.unity
@@ -209,6 +209,10 @@ PrefabInstance:
       propertyPath: overrideDefaultInteractionDistance
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 5634723788117127374, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 7ce11d22-d2c8-4b27-831b-fab81587daca
+      objectReference: {fileID: 0}
     - target: {fileID: 6410608619545107928, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
       propertyPath: backingHandlerGUID
       value: e58467b4-9a7b-4a74-b8d5-b87db8f7e2af
@@ -2524,6 +2528,10 @@ PrefabInstance:
       propertyPath: overrideDefaultInteractionDistance
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 5634723788117127374, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 902c7cec-7d50-4e71-a11b-a03cb69f9f79
+      objectReference: {fileID: 0}
     - target: {fileID: 6410608619545107928, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
       propertyPath: backingHandlerGUID
       value: d240f7e7-56d5-48a6-b7a1-6d07bd36fe0f
@@ -3425,6 +3433,10 @@ PrefabInstance:
     - target: {fileID: 3450367177837436829, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
       propertyPath: overrideDefaultInteractionDistance
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5634723788117127374, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
+      propertyPath: uniqueIdentifier
+      value: 193ba495-eccf-41ab-b90c-1f30f244b446
       objectReference: {fileID: 0}
     - target: {fileID: 6410608619545107928, guid: 0933637bb54f1cb4480c3b6eaceeee40, type: 3}
       propertyPath: backingHandlerGUID

--- a/Assets/Scripts/CheckInteractions/CheckBase.cs
+++ b/Assets/Scripts/CheckInteractions/CheckBase.cs
@@ -50,7 +50,7 @@ namespace Frankie.Control
         #region SaveInterface
         public LoadPriority GetLoadPriority() => LoadPriority.ObjectProperty;
 
-        public SaveState CaptureState() => ManualGetStateFromData(activeCheck);
+        public virtual SaveState CaptureState() => ManualGetStateFromData(activeCheck);
 
         public virtual void RestoreState(SaveState saveState)
         {
@@ -65,7 +65,7 @@ namespace Frankie.Control
         {
             if (saveState != null && saveState.TryGetState(out value)) { return true; }
             value = activeCheck;
-            return false;
+            return true;
         }
     }
 }

--- a/Assets/Scripts/CheckInteractions/CheckBase.cs
+++ b/Assets/Scripts/CheckInteractions/CheckBase.cs
@@ -62,8 +62,8 @@ namespace Frankie.Control
 
         public bool ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState == null) { return activeCheck; }
-            return (bool)saveState.GetState(typeof(bool));
+            if (saveState == null || !saveState.TryGetState(out bool value)) { return activeCheck; }
+            return value;
         }
     }
 }

--- a/Assets/Scripts/CheckInteractions/CheckBase.cs
+++ b/Assets/Scripts/CheckInteractions/CheckBase.cs
@@ -54,16 +54,18 @@ namespace Frankie.Control
 
         public virtual void RestoreState(SaveState saveState)
         {
-            SetActiveCheck(ManualGetDataFromState(saveState));
+            TryManualGetDataFromState(saveState, out bool value);
+            SetActiveCheck(value);
         }
         #endregion
 
         public SaveState ManualGetStateFromData(bool data) => new(GetLoadPriority(), data);
 
-        public bool ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out bool value)
         {
-            if (saveState == null || !saveState.TryGetState(out bool value)) { return activeCheck; }
-            return value;
+            if (saveState != null && saveState.TryGetState(out value)) { return true; }
+            value = activeCheck;
+            return false;
         }
     }
 }

--- a/Assets/Scripts/CheckInteractions/CheckWithToggleChildren.cs
+++ b/Assets/Scripts/CheckInteractions/CheckWithToggleChildren.cs
@@ -108,11 +108,11 @@ namespace Frankie.Control
         #endregion
         
         #region SaveInterface
-        public override void RestoreState(SaveState state)
+        public override void RestoreState(SaveState saveState)
         {
-            if (state == null) { return; }
+            if (saveState == null) { return; }
 
-            if (!(bool)state.GetState(typeof(bool)))
+            if (saveState.TryGetState(out bool isActive) && !isActive)
             {
                 // Reset children, as condition was met on prior save
                 if (parentTransformForToggling == null) { parentTransformForToggling = transform; }
@@ -122,7 +122,7 @@ namespace Frankie.Control
                 }
                 childrenStateSetBySave = true;
             }
-            base.RestoreState(state);
+            base.RestoreState(saveState);
         }
         #endregion
     }

--- a/Assets/Scripts/Combat/CombatParticipant/CombatParticipant.cs
+++ b/Assets/Scripts/Combat/CombatParticipant/CombatParticipant.cs
@@ -563,10 +563,12 @@ namespace Frankie.Combat
         public bool TryManualGetDataFromState(SaveState saveState, out CombatParticipantSaveData combatParticipantSaveData)
         {
             if (saveState != null && saveState.TryGetState(out combatParticipantSaveData)) { return true; }
+            
+            // Default Pass Back
             combatParticipantSaveData = usesAP
                 ? new CombatParticipantSaveData(false, 1.0f, 1.0f)
                 : new CombatParticipantSaveData(false, 1.0f, Mathf.Infinity);
-            return false;
+            return true;
         }
         // Predicate Evaluation
         public bool? Evaluate(Predicate predicate)

--- a/Assets/Scripts/Combat/CombatParticipant/CombatParticipant.cs
+++ b/Assets/Scripts/Combat/CombatParticipant/CombatParticipant.cs
@@ -560,13 +560,13 @@ namespace Frankie.Combat
         
         public SaveState ManualGetStateFromData(CombatParticipantSaveData data) => new(GetLoadPriority(), data);
 
-        public CombatParticipantSaveData ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out CombatParticipantSaveData combatParticipantSaveData)
         {
-            if (saveState != null && saveState.TryGetState(out CombatParticipantSaveData combatParticipantSaveData)) { return combatParticipantSaveData; }
+            if (saveState != null && saveState.TryGetState(out combatParticipantSaveData)) { return true; }
             combatParticipantSaveData = usesAP
                 ? new CombatParticipantSaveData(false, 1.0f, 1.0f)
                 : new CombatParticipantSaveData(false, 1.0f, Mathf.Infinity);
-            return combatParticipantSaveData;
+            return false;
         }
         // Predicate Evaluation
         public bool? Evaluate(Predicate predicate)

--- a/Assets/Scripts/Combat/CombatParticipant/CombatParticipant.cs
+++ b/Assets/Scripts/Combat/CombatParticipant/CombatParticipant.cs
@@ -540,7 +540,7 @@ namespace Frankie.Combat
         
         public void RestoreState(SaveState saveState)
         {
-            if (saveState.GetState(typeof(CombatParticipantSaveData)) is not CombatParticipantSaveData combatParticipantSaveData) { return; }
+            if (!saveState.TryGetState(out CombatParticipantSaveData combatParticipantSaveData)) { return; }
 
             SetupLazyState();
             isDead.value = combatParticipantSaveData.isDead;
@@ -562,8 +562,7 @@ namespace Frankie.Combat
 
         public CombatParticipantSaveData ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState?.GetState(typeof(CombatParticipantSaveData)) is CombatParticipantSaveData combatParticipantSaveData) { return combatParticipantSaveData; }
-            
+            if (saveState != null && saveState.TryGetState(out CombatParticipantSaveData combatParticipantSaveData)) { return combatParticipantSaveData; }
             combatParticipantSaveData = usesAP
                 ? new CombatParticipantSaveData(false, 1.0f, 1.0f)
                 : new CombatParticipantSaveData(false, 1.0f, Mathf.Infinity);

--- a/Assets/Scripts/Combat/Spawner/EnemySpawner.cs
+++ b/Assets/Scripts/Combat/Spawner/EnemySpawner.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using Frankie.Stats;
+using Frankie.Saving;
 using Frankie.Utils;
 using Frankie.ZoneManagement;
 
@@ -61,6 +62,8 @@ namespace Frankie.Combat.Spawner
                 if (enemyPrefab == null) { continue; }
 
                 GameObject spawnedEnemy = Instantiate(enemyPrefab, transform);
+                PreventSpawnedEnemySave(spawnedEnemy);
+                
                 float xJitter = UnityEngine.Random.Range(-xJitterDistance, xJitterDistance);
                 float yJitter = UnityEngine.Random.Range(-yJitterDistance, yJitterDistance);
                 var jitterVector = new Vector3(xJitter, yJitter, 0f);
@@ -87,6 +90,15 @@ namespace Frankie.Combat.Spawner
         {
             SpawnConfiguration spawnConfiguration = ProbabilityPairOperation<SpawnConfiguration>.GetRandomObject(spawnConfigurations);
             return spawnConfiguration;
+        }
+
+        private static void PreventSpawnedEnemySave(GameObject spawnedEnemy)
+        {
+            if (spawnedEnemy == null) { return; }
+            foreach (SaveableEntity saveableEntity in spawnedEnemy.GetComponentsInChildren<SaveableEntity>(true))
+            {
+                saveableEntity.ForcePreventSave();
+            }
         }
         #endregion
 

--- a/Assets/Scripts/Control/Movement/Mover.cs
+++ b/Assets/Scripts/Control/Movement/Mover.cs
@@ -286,10 +286,11 @@ namespace Frankie.Control
 
         public SaveState ManualGetStateFromData(SerializableVector2 data) => new(GetLoadPriority(), data);
 
-        public SerializableVector2 ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out SerializableVector2 serializableVector2)
         {
-            if (saveState == null || !saveState.TryGetState(out SerializableVector2 serializableVector2)) { return null; }
-            return serializableVector2;
+            if (saveState != null && saveState.TryGetState(out serializableVector2)) { return true; }
+            serializableVector2 = null;
+            return false;
         }
         #endregion
     }

--- a/Assets/Scripts/Control/Movement/Mover.cs
+++ b/Assets/Scripts/Control/Movement/Mover.cs
@@ -285,7 +285,12 @@ namespace Frankie.Control
         public abstract void RestoreState(SaveState saveState);
 
         public SaveState ManualGetStateFromData(SerializableVector2 data) => new(GetLoadPriority(), data);
-        public SerializableVector2 ManualGetDataFromState(SaveState saveState) => saveState?.GetState(typeof(SerializableVector2)) as SerializableVector2;
+
+        public SerializableVector2 ManualGetDataFromState(SaveState saveState)
+        {
+            if (saveState == null || !saveState.TryGetState(out SerializableVector2 serializableVector2)) { return null; }
+            return serializableVector2;
+        }
         #endregion
     }
 }

--- a/Assets/Scripts/Control/Movement/NPCMover.cs
+++ b/Assets/Scripts/Control/Movement/NPCMover.cs
@@ -337,8 +337,7 @@ namespace Frankie.Control
 
         public override void RestoreState(SaveState saveState)
         {
-            SerializableVector2 savedPosition = ManualGetDataFromState(saveState);
-            if (savedPosition == null) { return; }
+             if (!TryManualGetDataFromState(saveState, out SerializableVector2 savedPosition)) { return; }
 
             // Force initialization for objects set to disable
             SelfInitializeRigidBody();

--- a/Assets/Scripts/Control/Movement/PlayerMover.cs
+++ b/Assets/Scripts/Control/Movement/PlayerMover.cs
@@ -202,8 +202,7 @@ namespace Frankie.Control
 
         public override void RestoreState(SaveState saveState)
         {
-            SerializableVector2 savedPosition = ManualGetDataFromState(saveState);
-            if (savedPosition == null) { return; }
+            if (!TryManualGetDataFromState(saveState, out SerializableVector2 savedPosition)) { return; }
 
             // Force initialization for objects set to disable
             SelfInitializeRigidBody();

--- a/Assets/Scripts/Control/NPC/NPCStateHandler.cs
+++ b/Assets/Scripts/Control/NPC/NPCStateHandler.cs
@@ -200,11 +200,7 @@ namespace Frankie.Control
             PlayerStateMachine playerStateMachine = Player.FindPlayerStateMachine();
             if (playerStateMachine == null) { return; }
 
-            Dialogue dialogue = aiConversant.GetDialogue();
-            if (dialogue == null) { return; }
-
-            playerStateMachine.EnterDialogue(aiConversant, dialogue);
-            SetNPCState(NPCStateType.Occupied);
+            aiConversant.ForceInteractionEvent(playerStateMachine);
         }
         
         private void CheckForNPCAfraid(IPlayerStateContext playerStateContext, bool overrideStateCheck = false)

--- a/Assets/Scripts/Control/Player/PlayerColliderTrigger.cs
+++ b/Assets/Scripts/Control/Player/PlayerColliderTrigger.cs
@@ -50,8 +50,8 @@ namespace Frankie.Control
 
         public bool ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState == null) { return triggered; }
-            return (bool)saveState.GetState(typeof(bool));
+            if (saveState == null || !saveState.TryGetState(out bool value)) { return triggered; }
+            return value;
         }
     }
 }

--- a/Assets/Scripts/Control/Player/PlayerColliderTrigger.cs
+++ b/Assets/Scripts/Control/Player/PlayerColliderTrigger.cs
@@ -52,7 +52,7 @@ namespace Frankie.Control
         {
             if (saveState != null && saveState.TryGetState(out value)) { return true; }
             value = triggered;
-            return false;
+            return true;
         }
     }
 }

--- a/Assets/Scripts/Control/Player/PlayerColliderTrigger.cs
+++ b/Assets/Scripts/Control/Player/PlayerColliderTrigger.cs
@@ -42,16 +42,17 @@ namespace Frankie.Control
 
         public void RestoreState(SaveState saveState)
         {
-            triggered = ManualGetDataFromState(saveState);
+            TryManualGetDataFromState(saveState, out triggered);
             ReconcileState();
         }
 
         public SaveState ManualGetStateFromData(bool data) => new(GetLoadPriority(), data);
 
-        public bool ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out bool value)
         {
-            if (saveState == null || !saveState.TryGetState(out bool value)) { return triggered; }
-            return value;
+            if (saveState != null && saveState.TryGetState(out value)) { return true; }
+            value = triggered;
+            return false;
         }
     }
 }

--- a/Assets/Scripts/Core/CameraCinematics/CinematicTrigger.cs
+++ b/Assets/Scripts/Core/CameraCinematics/CinematicTrigger.cs
@@ -66,7 +66,7 @@ namespace Frankie.Core
         {
             if (saveState != null && saveState.TryGetState(out value)) { return true; }
             value = isTriggered;
-            return false;
+            return true;
         }
     }
 }

--- a/Assets/Scripts/Core/CameraCinematics/CinematicTrigger.cs
+++ b/Assets/Scripts/Core/CameraCinematics/CinematicTrigger.cs
@@ -64,8 +64,8 @@ namespace Frankie.Core
 
         public bool ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState == null) { return isTriggered; }
-            return (bool)saveState.GetState(typeof(bool));
+            if (saveState == null || !saveState.TryGetState(out bool value)) { return isTriggered; }
+            return value;
         }
     }
 }

--- a/Assets/Scripts/Core/CameraCinematics/CinematicTrigger.cs
+++ b/Assets/Scripts/Core/CameraCinematics/CinematicTrigger.cs
@@ -57,15 +57,16 @@ namespace Frankie.Core
 
         public void RestoreState(SaveState saveState)
         {
-            isTriggered = ManualGetDataFromState(saveState);
+            TryManualGetDataFromState(saveState, out isTriggered);
         }
 
         public SaveState ManualGetStateFromData(bool data) => new(GetLoadPriority(), data);
 
-        public bool ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out bool value)
         {
-            if (saveState == null || !saveState.TryGetState(out bool value)) { return isTriggered; }
-            return value;
+            if (saveState != null && saveState.TryGetState(out value)) { return true; }
+            value = isTriggered;
+            return false;
         }
     }
 }

--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -165,7 +165,7 @@ namespace Frankie.Inventory
         private static Dictionary<EquipLocation, EquipableItemBase> UnpackSaveData(SaveState saveState)
         {
             Dictionary<EquipLocation, EquipableItemBase> saveData = new Dictionary<EquipLocation, EquipableItemBase>();
-            if (saveState?.GetState(typeof(Dictionary<EquipLocation, string>)) is not Dictionary<EquipLocation, string> equippedItemsForSerialization) { return saveData; }
+            if (saveState == null || !saveState.TryGetState(out Dictionary<EquipLocation, string> equippedItemsForSerialization)) { return saveData; }
 
             foreach (KeyValuePair<EquipLocation, string> pair in equippedItemsForSerialization)
             {

--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -135,21 +135,21 @@ namespace Frankie.Inventory
             return PackSaveData(GetLoadPriority(), filteredSaveData);
         }
 
-        public Dictionary<EquipLocation, EquipableItemBase> ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out Dictionary<EquipLocation, EquipableItemBase> dataSet)
         {
-            Dictionary<EquipLocation, EquipableItemBase> dataSet = new Dictionary<EquipLocation, EquipableItemBase>();
+            dataSet = new Dictionary<EquipLocation, EquipableItemBase>();
             foreach (EquipLocation equipLocation in Enum.GetValues(typeof(EquipLocation)))
             {
                 if (equipLocation == EquipLocation.None) { continue; }
                 dataSet[equipLocation] = null;
             }
-            if (saveState == null) { return dataSet; }
+            if (saveState == null) { return false; }
             
             foreach (KeyValuePair<EquipLocation, EquipableItemBase> pair in UnpackSaveData(saveState))
             {
                 dataSet[pair.Key] = pair.Value;
             }
-            return dataSet;
+            return true;
         }
         
         private static SaveState PackSaveData(LoadPriority loadPriority, Dictionary<EquipLocation, EquipableItemBase> saveData)

--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -138,13 +138,16 @@ namespace Frankie.Inventory
         public bool TryManualGetDataFromState(SaveState saveState, out Dictionary<EquipLocation, EquipableItemBase> dataSet)
         {
             dataSet = new Dictionary<EquipLocation, EquipableItemBase>();
+            
+            // Default Pass Back
             foreach (EquipLocation equipLocation in Enum.GetValues(typeof(EquipLocation)))
             {
                 if (equipLocation == EquipLocation.None) { continue; }
                 dataSet[equipLocation] = null;
             }
-            if (saveState == null) { return false; }
+            if (saveState == null) { return true; }
             
+            // Save Found Pass Back
             foreach (KeyValuePair<EquipLocation, EquipableItemBase> pair in UnpackSaveData(saveState))
             {
                 dataSet[pair.Key] = pair.Value;

--- a/Assets/Scripts/Inventory/Knapsack.cs
+++ b/Assets/Scripts/Inventory/Knapsack.cs
@@ -336,7 +336,7 @@ namespace Frankie.Inventory
         public ActiveInventoryItem[] ManualGetDataFromState(SaveState saveState)
         {
             var data = new ActiveInventoryItem[inventorySize];
-            if (saveState?.GetState(typeof(SaveableActiveItem[])) is not SaveableActiveItem[] slotsActiveItemStrings) { return data; }
+            if (saveState == null || !saveState.TryGetState(out SaveableActiveItem[] slotsActiveItemStrings)) { return data; }
             
             if (slotsActiveItemStrings.Length != inventorySize) { Array.Resize(ref slotsActiveItemStrings, inventorySize); }
             for (int i = 0; i < inventorySize; i++)

--- a/Assets/Scripts/Inventory/Knapsack.cs
+++ b/Assets/Scripts/Inventory/Knapsack.cs
@@ -309,7 +309,7 @@ namespace Frankie.Inventory
         
         public void RestoreState(SaveState saveState)
         {
-            slots = ManualGetDataFromState(saveState);
+            TryManualGetDataFromState(saveState, out slots);
             knapsackUpdated?.Invoke();
         }
 
@@ -333,10 +333,10 @@ namespace Frankie.Inventory
             return new SaveState(GetLoadPriority(), slotsActiveItemStrings);
         }
 
-        public ActiveInventoryItem[] ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out ActiveInventoryItem[] data)
         {
-            var data = new ActiveInventoryItem[inventorySize];
-            if (saveState == null || !saveState.TryGetState(out SaveableActiveItem[] slotsActiveItemStrings)) { return data; }
+            data = new ActiveInventoryItem[inventorySize];
+            if (saveState == null || !saveState.TryGetState(out SaveableActiveItem[] slotsActiveItemStrings)) { return false; }
             
             if (slotsActiveItemStrings.Length != inventorySize) { Array.Resize(ref slotsActiveItemStrings, inventorySize); }
             for (int i = 0; i < inventorySize; i++)
@@ -350,11 +350,8 @@ namespace Frankie.Inventory
 
                 data[i] = activeInventoryItem;
             }
-
-            return data;
+            return true;
         }
         #endregion
-
-
     }
 }

--- a/Assets/Scripts/Inventory/Knapsack.cs
+++ b/Assets/Scripts/Inventory/Knapsack.cs
@@ -336,8 +336,10 @@ namespace Frankie.Inventory
         public bool TryManualGetDataFromState(SaveState saveState, out ActiveInventoryItem[] data)
         {
             data = new ActiveInventoryItem[inventorySize];
-            if (saveState == null || !saveState.TryGetState(out SaveableActiveItem[] slotsActiveItemStrings)) { return false; }
+            // Default Pass Back
+            if (saveState == null || !saveState.TryGetState(out SaveableActiveItem[] slotsActiveItemStrings)) { return true; }
             
+            // Save Found Pass Back
             if (slotsActiveItemStrings.Length != inventorySize) { Array.Resize(ref slotsActiveItemStrings, inventorySize); }
             for (int i = 0; i < inventorySize; i++)
             {

--- a/Assets/Scripts/Inventory/Wallet.cs
+++ b/Assets/Scripts/Inventory/Wallet.cs
@@ -79,7 +79,7 @@ namespace Frankie.Inventory
 
         public void RestoreState(SaveState saveState)
         {
-            if (saveState.GetState(typeof(WalletSaveData)) is not WalletSaveData walletSaveData) { return; }
+            if (saveState == null || !saveState.TryGetState(out WalletSaveData walletSaveData)) { return; }
             cash.value = walletSaveData.cash;
             pendingCash = walletSaveData.pendingCash;
         }
@@ -88,7 +88,7 @@ namespace Frankie.Inventory
 
         public WalletSaveData ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState?.GetState(typeof(WalletSaveData)) is WalletSaveData walletSaveData) { return walletSaveData; }
+            if (saveState != null && saveState.TryGetState(out WalletSaveData walletSaveData)) { return walletSaveData; }
             return new WalletSaveData(initialCash, 0);
         }
         #endregion

--- a/Assets/Scripts/Inventory/Wallet.cs
+++ b/Assets/Scripts/Inventory/Wallet.cs
@@ -86,10 +86,11 @@ namespace Frankie.Inventory
         
         public SaveState ManualGetStateFromData(WalletSaveData data) => new(GetLoadPriority(), data);
 
-        public WalletSaveData ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out WalletSaveData walletSaveData)
         {
-            if (saveState != null && saveState.TryGetState(out WalletSaveData walletSaveData)) { return walletSaveData; }
-            return new WalletSaveData(initialCash, 0);
+            if (saveState != null && saveState.TryGetState(out walletSaveData)) { return true; }
+            walletSaveData = new WalletSaveData(initialCash, 0);
+            return false;
         }
         #endregion
     }

--- a/Assets/Scripts/Inventory/Wallet.cs
+++ b/Assets/Scripts/Inventory/Wallet.cs
@@ -89,8 +89,10 @@ namespace Frankie.Inventory
         public bool TryManualGetDataFromState(SaveState saveState, out WalletSaveData walletSaveData)
         {
             if (saveState != null && saveState.TryGetState(out walletSaveData)) { return true; }
+            
+            // Default Pass Back
             walletSaveData = new WalletSaveData(initialCash, 0);
-            return false;
+            return true;
         }
         #endregion
     }

--- a/Assets/Scripts/Predicates/PredicateChildToggler.cs
+++ b/Assets/Scripts/Predicates/PredicateChildToggler.cs
@@ -62,7 +62,7 @@ namespace Frankie.Core.Predicates
         {
             if (saveState != null && saveState.TryGetState(out value)) { return true; }
             value = childrenEnabled;
-            return false;
+            return true;
         }
         #endregion
     }

--- a/Assets/Scripts/Predicates/PredicateChildToggler.cs
+++ b/Assets/Scripts/Predicates/PredicateChildToggler.cs
@@ -52,16 +52,17 @@ namespace Frankie.Core.Predicates
 
         public void RestoreState(SaveState saveState)
         {
-            childrenEnabled = ManualGetDataFromState(saveState);
+            TryManualGetDataFromState(saveState, out childrenEnabled);
             foreach (Transform child in transform) { child.gameObject.SetActive(childrenEnabled); }
         }
         
         public SaveState ManualGetStateFromData(bool data) => new(GetLoadPriority(), data);
         
-        public bool ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out bool value)
         {
-            if (saveState == null || !saveState.TryGetState(out bool value)) { return childrenEnabled; }
-            return value;
+            if (saveState != null && saveState.TryGetState(out value)) { return true; }
+            value = childrenEnabled;
+            return false;
         }
         #endregion
     }

--- a/Assets/Scripts/Predicates/PredicateChildToggler.cs
+++ b/Assets/Scripts/Predicates/PredicateChildToggler.cs
@@ -60,8 +60,8 @@ namespace Frankie.Core.Predicates
         
         public bool ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState == null) { return childrenEnabled; }
-            return (bool)saveState.GetState(typeof(bool));
+            if (saveState == null || !saveState.TryGetState(out bool value)) { return childrenEnabled; }
+            return value;
         }
         #endregion
     }

--- a/Assets/Scripts/Quests/QuestList.cs
+++ b/Assets/Scripts/Quests/QuestList.cs
@@ -91,7 +91,9 @@ namespace Frankie.Quests
         public void RestoreState(SaveState saveState)
         {
             questStatuses.Clear();
-            foreach (QuestStatus questStatus in ManualGetDataFromState(saveState))
+            if (!TryManualGetDataFromState(saveState, out List<QuestStatus> data)) { return; }
+            
+            foreach (QuestStatus questStatus in data)
             {
                 questStatuses.Add(questStatus);
             }
@@ -104,10 +106,13 @@ namespace Frankie.Quests
             return new SaveState(GetLoadPriority(), serializableQuestStatuses);
         }
 
-        public List<QuestStatus> ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out List<QuestStatus> data)
         {
-            if (saveState == null || !saveState.TryGetState(out List<SerializableQuestStatus> serializableQuestStatuses)) { return new List<QuestStatus>(); }
-            return serializableQuestStatuses.Select(serializableQuestStatus => new QuestStatus(serializableQuestStatus)).ToList();
+            data = new List<QuestStatus>();
+            if (saveState == null || !saveState.TryGetState(out List<SerializableQuestStatus> serializableQuestStatuses)) { return false; }
+            
+            data = serializableQuestStatuses.Select(serializableQuestStatus => new QuestStatus(serializableQuestStatus)).ToList();
+            return true;
         }
         #endregion
     }

--- a/Assets/Scripts/Quests/QuestList.cs
+++ b/Assets/Scripts/Quests/QuestList.cs
@@ -109,8 +109,10 @@ namespace Frankie.Quests
         public bool TryManualGetDataFromState(SaveState saveState, out List<QuestStatus> data)
         {
             data = new List<QuestStatus>();
-            if (saveState == null || !saveState.TryGetState(out List<SerializableQuestStatus> serializableQuestStatuses)) { return false; }
+            // Default Pass Back
+            if (saveState == null || !saveState.TryGetState(out List<SerializableQuestStatus> serializableQuestStatuses)) { return true; }
             
+            // Save Found Pass Back
             data = serializableQuestStatuses.Select(serializableQuestStatus => new QuestStatus(serializableQuestStatus)).ToList();
             return true;
         }

--- a/Assets/Scripts/Quests/QuestList.cs
+++ b/Assets/Scripts/Quests/QuestList.cs
@@ -106,7 +106,7 @@ namespace Frankie.Quests
 
         public List<QuestStatus> ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState?.GetState(typeof(List<SerializableQuestStatus>)) is not List<SerializableQuestStatus> serializableQuestStatuses) { return new List<QuestStatus>(); }
+            if (saveState == null || !saveState.TryGetState(out List<SerializableQuestStatus> serializableQuestStatuses)) { return new List<QuestStatus>(); }
             return serializableQuestStatuses.Select(serializableQuestStatus => new QuestStatus(serializableQuestStatus)).ToList();
         }
         #endregion

--- a/Assets/Scripts/Saving/Editor/SaveEditor.cs
+++ b/Assets/Scripts/Saving/Editor/SaveEditor.cs
@@ -470,7 +470,7 @@ namespace Frankie.Saving.Editor
             
             cachedSaveableEntityCardData.Clear();
             saveableEntityGUIDs.Clear();
-            foreach (SaveableEntity saveableEntity in SavingSystem.GetAllSaveableEntities().OrderBy(SaveableEntityCardData.GetEntitySortPriority).ThenBy(saveableEntity => saveableEntity.name).ToList())
+            foreach (SaveableEntity saveableEntity in SavingSystem.GetValidSaveableEntities().OrderBy(SaveableEntityCardData.GetEntitySortPriority).ThenBy(saveableEntity => saveableEntity.name).ToList())
             {
                 if (saveableEntity == null) { continue; }
                 if (HasPlayerInParentHierarchy(saveableEntity.transform.parent)) { continue; } // Avoid re-pulling entries e.g. in party container

--- a/Assets/Scripts/Saving/Editor/SaveableSubCardData.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCardData.cs
@@ -9,6 +9,7 @@ using Frankie.Stats;
 using Frankie.Combat;
 using Frankie.Inventory;
 using Frankie.Quests;
+using Frankie.Speech;
 using Frankie.World;
 using Frankie.ZoneManagement;
 
@@ -54,6 +55,7 @@ namespace Frankie.Saving.Editor
                 Equipment => new EquipmentSaveableSubCard(saveable, saveState),
                 Wallet => new WalletSaveableSubCard(saveable, saveState),
                 QuestList => new QuestListSubCard(saveable, saveState),
+                AIConversant => new SimpleIntSaveableSubCard(saveable, saveState), // Child of CheckBase -> above in switch
                 CheckBase => new SimpleBoolSaveableSubCard(saveable, saveState),
                 PredicateChildToggler => new SimpleBoolSaveableSubCard(saveable, saveState),
                 CinematicTrigger => new SimpleBoolSaveableSubCard(saveable, saveState),

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/BaseStatsSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/BaseStatsSubCard.cs
@@ -22,7 +22,7 @@ namespace Frankie.Saving.Editor
             if (saveable is not BaseStats baseStats) { return; }
             if (!baseStats.TryManualGetDataFromState(saveState, out BaseStatsSaveData baseStatsSaveData))
             {
-                subCardView.Add(new Label("No BaseStats save data found"));
+                subCardView.Add(new Label("No BaseStats save data available"));
                 return;
             }
             

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/BaseStatsSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/BaseStatsSubCard.cs
@@ -20,9 +20,7 @@ namespace Frankie.Saving.Editor
         protected override void AddEditableFieldsToSubCardView(Box subCardView)
         {
             if (saveable is not BaseStats baseStats) { return; }
-            
-            BaseStatsSaveData baseStatsSaveData = baseStats.ManualGetDataFromState(saveState);
-            if (baseStatsSaveData?.statSheet == null)
+            if (!baseStats.TryManualGetDataFromState(saveState, out BaseStatsSaveData baseStatsSaveData))
             {
                 subCardView.Add(new Label("No BaseStats save data found"));
                 return;

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/CombatParticipantSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/CombatParticipantSaveableSubCard.cs
@@ -17,7 +17,7 @@ namespace Frankie.Saving.Editor
             if (saveable is not CombatParticipant combatParticipant) { return; }
             if (!combatParticipant.TryManualGetDataFromState(saveState, out CombatParticipantSaveData saveData))
             {
-                subCardView.Add(new Label("No CombatParticipant save data found"));
+                subCardView.Add(new Label("No CombatParticipant save data available"));
                 return;
             }
             

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/CombatParticipantSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/CombatParticipantSaveableSubCard.cs
@@ -15,8 +15,7 @@ namespace Frankie.Saving.Editor
         protected override void AddEditableFieldsToSubCardView(Box subCardView)
         { 
             if (saveable is not CombatParticipant combatParticipant) { return; }
-            CombatParticipantSaveData saveData = combatParticipant.ManualGetDataFromState(saveState);
-            if (saveData == null)
+            if (!combatParticipant.TryManualGetDataFromState(saveState, out CombatParticipantSaveData saveData))
             {
                 subCardView.Add(new Label("No CombatParticipant save data found"));
                 return;

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/EquipmentSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/EquipmentSaveableSubCard.cs
@@ -20,7 +20,7 @@ namespace Frankie.Saving.Editor
 
             if (!equipment.TryManualGetDataFromState(saveState, out Dictionary<EquipLocation, EquipableItemBase> equippedItems))
             {
-                subCardView.Add(new Label("No Equipment save data found"));
+                subCardView.Add(new Label("No Equipment save data available"));
                 return;
             }
             

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/EquipmentSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/EquipmentSaveableSubCard.cs
@@ -17,9 +17,8 @@ namespace Frankie.Saving.Editor
         protected override void AddEditableFieldsToSubCardView(Box subCardView)
         {
             if (saveable is not Equipment equipment) { return; }
-            
-            Dictionary<EquipLocation, EquipableItemBase> equippedItems = equipment.ManualGetDataFromState(saveState);
-            if (equippedItems == null || equippedItems.Count == 0)
+
+            if (!equipment.TryManualGetDataFromState(saveState, out Dictionary<EquipLocation, EquipableItemBase> equippedItems))
             {
                 subCardView.Add(new Label("No Equipment save data found"));
                 return;
@@ -56,7 +55,7 @@ namespace Frankie.Saving.Editor
         {
             if (saveable is not Equipment equipment) { return; }
             
-            Dictionary<EquipLocation, EquipableItemBase> equippedItems = equipment.ManualGetDataFromState(saveState);
+            if (!equipment.TryManualGetDataFromState(saveState, out Dictionary<EquipLocation, EquipableItemBase> equippedItems)) { return; }
             equippedItems[equipLocation] = null;
             
             saveState = equipment.ManualGetStateFromData(equippedItems);

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/InactivePartySubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/InactivePartySubCard.cs
@@ -16,9 +16,8 @@ namespace Frankie.Saving.Editor
         protected override void AddEditableFieldsToSubCardView(Box subCardView)
         {
             if (saveable is not InactiveParty inactiveParty) { return; }
-            
-            HashSet<CharacterProperties> inactivePartyData = inactiveParty.ManualGetDataFromState(saveState);
-            if (inactivePartyData == null)
+
+            if (!inactiveParty.TryManualGetDataFromState(saveState, out HashSet<CharacterProperties> inactivePartyData))
             {
                 subCardView.Add(new Label("No InactiveParty save data found"));
                 return;

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/InactivePartySubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/InactivePartySubCard.cs
@@ -19,7 +19,7 @@ namespace Frankie.Saving.Editor
 
             if (!inactiveParty.TryManualGetDataFromState(saveState, out HashSet<CharacterProperties> inactivePartyData))
             {
-                subCardView.Add(new Label("No InactiveParty save data found"));
+                subCardView.Add(new Label("No InactiveParty save data available"));
                 return;
             }
 

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/KnapsackSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/KnapsackSaveableSubCard.cs
@@ -19,7 +19,7 @@ namespace Frankie.Saving.Editor
             
             if (!knapsack.TryManualGetDataFromState(saveState, out ActiveInventoryItem[] itemsInKnapsack))
             {
-                subCardView.Add(new Label("No Knapsack save data found"));
+                subCardView.Add(new Label("No Knapsack save data available"));
                 return;
             }
             

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/KnapsackSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/KnapsackSaveableSubCard.cs
@@ -17,8 +17,7 @@ namespace Frankie.Saving.Editor
         {
             if (saveable is not Knapsack knapsack) { return; }
             
-            ActiveInventoryItem[] itemsInKnapsack = knapsack.ManualGetDataFromState(saveState);
-            if (itemsInKnapsack == null || itemsInKnapsack.Length == 0)
+            if (!knapsack.TryManualGetDataFromState(saveState, out ActiveInventoryItem[] itemsInKnapsack))
             {
                 subCardView.Add(new Label("No Knapsack save data found"));
                 return;
@@ -90,7 +89,7 @@ namespace Frankie.Saving.Editor
             if (equipableItem == null) { return; }
             
             if (saveable is not Knapsack knapsack) { return; }
-            ActiveInventoryItem[] itemsInKnapsack = knapsack.ManualGetDataFromState(saveState);
+            if (!knapsack.TryManualGetDataFromState(saveState, out ActiveInventoryItem[] itemsInKnapsack)) { return; }
             
             foreach (ActiveInventoryItem testItem in itemsInKnapsack)
             {
@@ -110,7 +109,7 @@ namespace Frankie.Saving.Editor
         {
             if (saveable is not Knapsack knapsack) { return false; }
             
-            ActiveInventoryItem[] itemsInKnapsack = knapsack.ManualGetDataFromState(saveState);
+            if (!knapsack.TryManualGetDataFromState(saveState, out ActiveInventoryItem[] itemsInKnapsack)) { return false; }
             int matchSlot = -1;
             int emptySlot = -1;
             for (int i = 0; i < itemsInKnapsack.Length; i++)

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/MoverSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/MoverSaveableSubCard.cs
@@ -35,7 +35,7 @@ namespace Frankie.Saving.Editor
 
             if (!mover.TryManualGetDataFromState(saveState, out SerializableVector2 savedPosition))
             {
-                subCardView.Add(new Label("No position currently saved"));
+                subCardView.Add(new Label("No position currently available"));
                 return;
             }
             

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/MoverSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/MoverSaveableSubCard.cs
@@ -32,9 +32,8 @@ namespace Frankie.Saving.Editor
         {
             CancelPickingIfActive();
             if (saveable is not Mover mover) { return; }
-            
-            SerializableVector2 savedPosition = mover.ManualGetDataFromState(saveState);
-            if (savedPosition == null)
+
+            if (!mover.TryManualGetDataFromState(saveState, out SerializableVector2 savedPosition))
             {
                 subCardView.Add(new Label("No position currently saved"));
                 return;

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/PartyAssistSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/PartyAssistSubCard.cs
@@ -17,8 +17,7 @@ namespace Frankie.Saving.Editor
         {
             if (saveable is not PartyAssist partyAssist) { return; }
             
-            HashSet<CharacterProperties> partyAssistSaveData = partyAssist.ManualGetDataFromState(saveState);
-            if (partyAssistSaveData == null)
+            if (!partyAssist.TryManualGetDataFromState(saveState, out HashSet<CharacterProperties> partyAssistSaveData))
             {
                 subCardView.Add(new Label("No PartyAssist save data found"));
                 return;

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/PartyAssistSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/PartyAssistSubCard.cs
@@ -19,7 +19,7 @@ namespace Frankie.Saving.Editor
             
             if (!partyAssist.TryManualGetDataFromState(saveState, out HashSet<CharacterProperties> partyAssistSaveData))
             {
-                subCardView.Add(new Label("No PartyAssist save data found"));
+                subCardView.Add(new Label("No PartyAssist save data available"));
                 return;
             }
 

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/PartySubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/PartySubCard.cs
@@ -20,8 +20,7 @@ namespace Frankie.Saving.Editor
         {
             if (saveable is not Party party) { return; }
             
-            PartySaveData partySaveData = party.ManualGetDataFromState(saveState);
-            if (partySaveData == null)
+            if (!party.TryManualGetDataFromState(saveState, out PartySaveData partySaveData))
             {
                 subCardView.Add(new Label("No Party save data found"));
                 return;

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/PartySubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/PartySubCard.cs
@@ -22,7 +22,7 @@ namespace Frankie.Saving.Editor
             
             if (!party.TryManualGetDataFromState(saveState, out PartySaveData partySaveData))
             {
-                subCardView.Add(new Label("No Party save data found"));
+                subCardView.Add(new Label("No Party save data available"));
                 return;
             }
 

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/QuestListSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/QuestListSubCard.cs
@@ -47,7 +47,7 @@ namespace Frankie.Saving.Editor
 
             if (questStatuses.Count == 0)
             {
-                listContainer.Add(new Label("No questList save data found"));
+                listContainer.Add(new Label("No questList save data available"));
                 return;
             }
 

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/QuestListSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/QuestListSubCard.cs
@@ -18,7 +18,7 @@ namespace Frankie.Saving.Editor
         {
             if (saveable is not QuestList questList) { return; }
             
-            List<QuestStatus> questStatuses = questList.ManualGetDataFromState(saveState);
+            if (!questList.TryManualGetDataFromState(saveState, out List<QuestStatus> questStatuses)) { return; }
             questStatuses ??= new List<QuestStatus>();
 
             var listContainer = new VisualElement();

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/SimpleBoolSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/SimpleBoolSaveableSubCard.cs
@@ -14,7 +14,7 @@ namespace Frankie.Saving.Editor
         protected override void AddEditableFieldsToSubCardView(Box subCardView)
         {
             if (saveable is not ISaveable<bool> boolSaveable) { return; }
-            bool setEnabled = boolSaveable.ManualGetDataFromState(saveState);
+           boolSaveable.TryManualGetDataFromState(saveState, out bool setEnabled);
 
             var boolRow = new VisualElement { style = { flexDirection = FlexDirection.Row } };
             subCardView.Add(boolRow);

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/SimpleBoolSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/SimpleBoolSaveableSubCard.cs
@@ -14,7 +14,12 @@ namespace Frankie.Saving.Editor
         protected override void AddEditableFieldsToSubCardView(Box subCardView)
         {
             if (saveable is not ISaveable<bool> boolSaveable) { return; }
-           boolSaveable.TryManualGetDataFromState(saveState, out bool setEnabled);
+
+            if (!boolSaveable.TryManualGetDataFromState(saveState, out bool setEnabled))
+            {
+                subCardView.Add(new Label("No save data available"));
+                return;
+            }
 
             var boolRow = new VisualElement { style = { flexDirection = FlexDirection.Row } };
             subCardView.Add(boolRow);

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/SimpleFloatSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/SimpleFloatSaveableSubCard.cs
@@ -14,7 +14,7 @@ namespace Frankie.Saving.Editor
         protected override void AddEditableFieldsToSubCardView(Box subCardView)
         {
             if (saveable is not ISaveable<float> floatSaveable) { return; }
-            float value = floatSaveable.ManualGetDataFromState(saveState);
+            floatSaveable.TryManualGetDataFromState(saveState, out float value);
             
             var floatRow = new VisualElement { style = { flexDirection = FlexDirection.Row } };
             subCardView.Add(floatRow);

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/SimpleFloatSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/SimpleFloatSaveableSubCard.cs
@@ -14,7 +14,12 @@ namespace Frankie.Saving.Editor
         protected override void AddEditableFieldsToSubCardView(Box subCardView)
         {
             if (saveable is not ISaveable<float> floatSaveable) { return; }
-            floatSaveable.TryManualGetDataFromState(saveState, out float value);
+
+            if (!floatSaveable.TryManualGetDataFromState(saveState, out float value))
+            {
+                subCardView.Add(new Label("No save data available"));
+                return;
+            }
             
             var floatRow = new VisualElement { style = { flexDirection = FlexDirection.Row } };
             subCardView.Add(floatRow);

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/SimpleIntSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/SimpleIntSaveableSubCard.cs
@@ -14,7 +14,7 @@ namespace Frankie.Saving.Editor
         protected override void AddEditableFieldsToSubCardView(Box subCardView)
         {
             if (saveable is not ISaveable<int> intSaveable) { return; }
-            int value = intSaveable.ManualGetDataFromState(saveState);
+            intSaveable.TryManualGetDataFromState(saveState, out int value);
             
             var intRow = new VisualElement { style = { flexDirection = FlexDirection.Row } };
             subCardView.Add(intRow);

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/SimpleIntSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/SimpleIntSaveableSubCard.cs
@@ -14,7 +14,11 @@ namespace Frankie.Saving.Editor
         protected override void AddEditableFieldsToSubCardView(Box subCardView)
         {
             if (saveable is not ISaveable<int> intSaveable) { return; }
-            intSaveable.TryManualGetDataFromState(saveState, out int value);
+            if (!intSaveable.TryManualGetDataFromState(saveState, out int value))
+            {
+                subCardView.Add(new Label("No save data available"));
+                return;
+            }
             
             var intRow = new VisualElement { style = { flexDirection = FlexDirection.Row } };
             subCardView.Add(intRow);

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/WalletSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/WalletSaveableSubCard.cs
@@ -17,7 +17,7 @@ namespace Frankie.Saving.Editor
             if (saveable is not Wallet wallet) { return; }
             if (!wallet.TryManualGetDataFromState(saveState, out WalletSaveData saveData))
             {
-                subCardView.Add(new Label("No Wallet save data found"));
+                subCardView.Add(new Label("No Wallet save data available"));
                 return;
             }
 

--- a/Assets/Scripts/Saving/Editor/SaveableSubCards/WalletSaveableSubCard.cs
+++ b/Assets/Scripts/Saving/Editor/SaveableSubCards/WalletSaveableSubCard.cs
@@ -15,8 +15,7 @@ namespace Frankie.Saving.Editor
         protected override void AddEditableFieldsToSubCardView(Box subCardView)
         {
             if (saveable is not Wallet wallet) { return; }
-            WalletSaveData saveData = wallet.ManualGetDataFromState(saveState);
-            if (saveData == null)
+            if (!wallet.TryManualGetDataFromState(saveState, out WalletSaveData saveData))
             {
                 subCardView.Add(new Label("No Wallet save data found"));
                 return;

--- a/Assets/Scripts/Saving/ISaveable.cs
+++ b/Assets/Scripts/Saving/ISaveable.cs
@@ -4,5 +4,7 @@ namespace Frankie.Saving
     {
         SaveState ManualGetStateFromData(T data);
         public bool TryManualGetDataFromState(SaveState saveState, out T value);
+            // bool return::  signifies valid data on value (including default data)
+            // Only set to false on null or invalid data -- see Mover, BaseStats e.g.
     }
 }

--- a/Assets/Scripts/Saving/ISaveable.cs
+++ b/Assets/Scripts/Saving/ISaveable.cs
@@ -3,6 +3,6 @@ namespace Frankie.Saving
     public interface ISaveable<T> : ISaveableBase
     {
         SaveState ManualGetStateFromData(T data);
-        public T ManualGetDataFromState(SaveState saveState);
+        public bool TryManualGetDataFromState(SaveState saveState, out T value);
     }
 }

--- a/Assets/Scripts/Saving/SaveState.cs
+++ b/Assets/Scripts/Saving/SaveState.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json.Linq;
 using System;
+using Frankie.Utils;
 
 namespace Frankie.Saving
 {
@@ -18,7 +19,7 @@ namespace Frankie.Saving
             this.state = JToken.FromObject(state);
         }
 
-        public object GetState(Type type) => state.ToObject(type); 
+        public bool TryGetState<T>(out T value) => state.TryToObject(out value); 
         public LoadPriority GetLoadPriority() => loadPriority;
     }
 }

--- a/Assets/Scripts/Saving/SaveableEntity.cs
+++ b/Assets/Scripts/Saving/SaveableEntity.cs
@@ -4,10 +4,11 @@ using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
-using UnityEditor;
 #if UNITY_EDITOR
+using UnityEditor;
 using UnityEditor.SceneManagement;
 #endif
+using Frankie.Utils;
 
 namespace Frankie.Saving
 {
@@ -18,14 +19,20 @@ namespace Frankie.Saving
         [SerializeField] private string uniqueIdentifier = "";
         private static readonly Dictionary<string, SaveableEntity> _globalLookupForEditorDebug = new();
         
+        // State
+        private bool forcePreventSave = false;
+        
         // Constants
         private const string _uniquePropertyRef = "uniqueIdentifier";
-
+        
+        #region PublicPropertyMethods
         public string GetUniqueIdentifier()
         {
             if (string.IsNullOrWhiteSpace(uniqueIdentifier)) { uniqueIdentifier = Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture); }
             return uniqueIdentifier;
         }
+        public void ForcePreventSave() => forcePreventSave = true;
+        public bool IsSaveRestricted() => forcePreventSave;
         
         public List<ISaveableBase> GetSaveableComponents() => GetComponents<ISaveableBase>().ToList();
         
@@ -38,10 +45,14 @@ namespace Frankie.Saving
             if (stateDictionary == null) { Debug.LogError("Malformed data in save file"); return false; }
             return true;
         }
+        #endregion
         
-        public JToken CaptureState(JToken existingTokenState, bool onlyCorePlayerState = false)
+        #region CaptureRestoreMethods
+        public bool TryCaptureState(JToken existingTokenState, out JToken updatedTokenState, bool onlyCorePlayerState = false)
         {
-            JToken updatedTokenState = existingTokenState ?? new JObject();
+            updatedTokenState = existingTokenState ?? new JObject();
+            if (IsSaveRestricted()) { return false; }
+            
             foreach (ISaveableBase saveable in GetComponents<ISaveableBase>())
             {
                 // Core Player State captures, e.g. for GameOver saves (skip saving position, etc.)
@@ -51,7 +62,8 @@ namespace Frankie.Saving
                 if (saveState == null) { continue; }
                 updatedTokenState[saveable.GetType().ToString()] = JToken.FromObject(saveState); // Type ToString does not require CultureInvariant
             }
-            return updatedTokenState;
+
+            return !updatedTokenState.IsNullOrEmpty();
         }
 
         public void RestoreState(JToken state, LoadPriority loadPriority)
@@ -74,7 +86,9 @@ namespace Frankie.Saving
                 saveable.ApplyFinishingTouches();
             }
         }
+        #endregion
 
+        #region PrivateMethods
         private static IEnumerable<(ISaveableBase, SaveState)> MatchSaveableToState(IEnumerable<ISaveableBase> saveableEntries, JObject stateDictionary)
         {
             foreach (ISaveableBase saveable in saveableEntries)
@@ -94,7 +108,9 @@ namespace Frankie.Saving
             updatedStateDictionary[typeString] = JToken.FromObject(updatedSaveState);
             return updatedStateDictionary;
         }
+        #endregion
         
+        #region EditorMethods
 #if UNITY_EDITOR
         private void Update()
         {
@@ -127,5 +143,6 @@ namespace Frankie.Saving
             return false;
         }
 #endif
+        #endregion
     }
 }

--- a/Assets/Scripts/Saving/SavingSystem.cs
+++ b/Assets/Scripts/Saving/SavingSystem.cs
@@ -17,7 +17,7 @@ namespace Frankie.Saving
         // Constants
         private const string _saveFileExtension = ".sav";
         private const string _saveLastSceneBuildIndex = "lastSceneBuildIndex";
-        private const bool _encryptionEnabled = true;
+        private const bool _encryptionEnabled = false;
 
         #region DataStructures
         [System.Serializable]

--- a/Assets/Scripts/Saving/SavingSystem.cs
+++ b/Assets/Scripts/Saving/SavingSystem.cs
@@ -178,17 +178,7 @@ namespace Frankie.Saving
             {
                 return new JObject();
             }
-
-            // Binary Formatter Method -- Deprecated
-            /*
-            using (FileStream stream = File.Open(path, FileMode.Open))
-            {
-                BinaryFormatter formatter = new BinaryFormatter();
-                return (Dictionary<string, object>)formatter.Deserialize(stream);
-            }
-            */
-
-            // JSON Method
+            
             using (StreamReader textReader = File.OpenText(path))
             {
                 using (var reader = new JsonTextReader(textReader))
@@ -214,17 +204,7 @@ namespace Frankie.Saving
         {
             string path = GetPathFromSaveFile(saveFile);
             Debug.Log($"Saving to {path}");
-
-            // Binary Formatter Method
-            /*
-            using (FileStream stream = File.Open(path, FileMode.Create))
-            {
-                BinaryFormatter formatter = new BinaryFormatter();
-                formatter.Serialize(stream, state);
-            }
-            */
-
-            // JSON Method
+            
             using (StreamWriter textWriter = File.CreateText(path))
             {
                 // Note - When using standard SerializeObject() methods, default setting for JsonSerializationSettings is:  InvariantCulture

--- a/Assets/Scripts/Saving/SavingSystem.cs
+++ b/Assets/Scripts/Saving/SavingSystem.cs
@@ -46,9 +46,9 @@ namespace Frankie.Saving
             }
         }
         
-        public static List<SaveableEntity> GetAllSaveableEntities()
+        public static List<SaveableEntity> GetValidSaveableEntities()
         {
-            List<SaveableEntity> saveableEntities = Object.FindObjectsByType<SaveableEntity>(FindObjectsInactive.Include).ToList();
+            List<SaveableEntity> saveableEntities = Object.FindObjectsByType<SaveableEntity>(FindObjectsInactive.Include).Where(saveableEntity => !saveableEntity.IsSaveRestricted()).ToList();
             foreach (SaveableEntity saveableEntity in saveableEntities.Where(saveableEntity => !saveableEntity.gameObject.activeSelf))
             {
                 // Manually toggle enable/disable to ensure base properties set
@@ -226,11 +226,11 @@ namespace Frankie.Saving
 
         private static void CaptureState(JObject state, bool onlyCorePlayerState = false)
         {
-            List<SaveableEntity> saveableEntities = GetAllSaveableEntities();
-            foreach (SaveableEntity saveable in saveableEntities)
+            foreach (SaveableEntity saveable in GetValidSaveableEntities())
             {
                 if (!state.TryGetValue(saveable.GetUniqueIdentifier(), out JToken existingTokenState)) { existingTokenState = new JObject(); }
-                state[saveable.GetUniqueIdentifier()] = saveable.CaptureState(existingTokenState, onlyCorePlayerState);
+                if (!saveable.TryCaptureState(existingTokenState, out JToken updatedTokenState, onlyCorePlayerState)) { continue; }
+                state[saveable.GetUniqueIdentifier()] = updatedTokenState;
             }
 
             if (!onlyCorePlayerState) { state[_saveLastSceneBuildIndex] = SceneManager.GetActiveScene().name; }
@@ -239,15 +239,17 @@ namespace Frankie.Saving
         private static void CaptureIndividualState(JObject state, SaveableEntity saveable)
         {
             if (saveable == null) { return; }
+            if (saveable.IsSaveRestricted()) { return; }
             
             if (!state.TryGetValue(saveable.GetUniqueIdentifier(), out JToken existingTokenState)) { existingTokenState = new JObject(); }
-            state[saveable.GetUniqueIdentifier()] = saveable.CaptureState(existingTokenState);
+            if (!saveable.TryCaptureState(existingTokenState, out JToken updatedTokenState)) { return; }
+            state[saveable.GetUniqueIdentifier()] = updatedTokenState;
         }
 
         private static void RestoreState(JObject state)
         {
             // First Pass -- Object instantiation
-            List<SaveableEntity> saveableEntities = GetAllSaveableEntities();
+            List<SaveableEntity> saveableEntities = GetValidSaveableEntities();
             foreach (SaveableEntity saveable in saveableEntities)
             {
                 string id = saveable.GetUniqueIdentifier();
@@ -258,7 +260,7 @@ namespace Frankie.Saving
             }
 
             // Second Pass -- Property loading
-            saveableEntities = GetAllSaveableEntities();
+            saveableEntities = GetValidSaveableEntities();
             foreach (SaveableEntity saveable in saveableEntities)
             {
                 string id = saveable.GetUniqueIdentifier();

--- a/Assets/Scripts/Sound/BackgroundMusic.cs
+++ b/Assets/Scripts/Sound/BackgroundMusic.cs
@@ -24,7 +24,6 @@ namespace Frankie.Sound
         private AudioClip currentWorldMusic;
         private bool isWorldMusicLooping = true;
         private float worldMusicTimeIndex = 0f;
-        private bool wasMusicOverriddenOnStart = false;
 
         // Cached References
         private AudioSource audioSource;
@@ -167,16 +166,17 @@ namespace Frankie.Sound
         private void ConfigureNewWorldAudio(AudioClip audioClip, bool isLooping, bool immediate = false)
         {
             if (audioClip == null) { return; }
-
-            if (!wasMusicOverriddenOnStart)
-            {
-                if (musicFadeCoroutine != null) { StopCoroutine(musicFadeCoroutine); }
-                musicFadeCoroutine = StartCoroutine(immediate
-                    ? TransitionToAudioImmediate(audioClip, isLooping)
-                    : TransitionToAudio(audioClip, isLooping));
-            }
             currentWorldMusic = audioClip;
             isWorldMusicLooping = isLooping;
+            
+            if (BackgroundMusicOverride.TryGetHighestPriorityActiveOverride(out BackgroundMusicOverride backgroundMusicOverride) && backgroundMusicOverride.HasAudioOverride())
+            {
+                OverrideMusic(backgroundMusicOverride.GetAudioClip());
+                return;
+            }
+            
+            if (musicFadeCoroutine != null) { StopCoroutine(musicFadeCoroutine); }
+            musicFadeCoroutine = StartCoroutine(immediate ? TransitionToAudioImmediate(audioClip, isLooping) : TransitionToAudio(audioClip, isLooping));
         }
         #endregion
 
@@ -206,11 +206,9 @@ namespace Frankie.Sound
         #endregion
 
         #region MusicOverrides
-        public bool OverrideMusic(AudioClip audioClip, bool calledInStart = false)
+        public bool OverrideMusic(AudioClip audioClip)
         {
             if (audioClip == null) { return false; }
-            if (calledInStart) { wasMusicOverriddenOnStart = true; }
-
             worldMusicTimeIndex = audioSource.time;
             if (musicFadeCoroutine != null) { StopCoroutine(musicFadeCoroutine); }
             musicFadeCoroutine = StartCoroutine(TransitionToAudio(audioClip, true));

--- a/Assets/Scripts/Sound/BackgroundMusicOverride.cs
+++ b/Assets/Scripts/Sound/BackgroundMusicOverride.cs
@@ -124,8 +124,8 @@ namespace Frankie.Sound
         
         public bool ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState == null) { return isOverrideActive; }
-            return (bool)saveState.GetState(typeof(bool));
+            if (saveState == null || !saveState.TryGetState(out bool value)) { return isOverrideActive; }
+            return value;
         }
         #endregion
     }

--- a/Assets/Scripts/Sound/BackgroundMusicOverride.cs
+++ b/Assets/Scripts/Sound/BackgroundMusicOverride.cs
@@ -126,7 +126,7 @@ namespace Frankie.Sound
         {
             if (saveState != null && saveState.TryGetState(out value)) { return true; }
             value = isOverrideActive;
-            return false;
+            return true;
         }
         #endregion
     }

--- a/Assets/Scripts/Sound/BackgroundMusicOverride.cs
+++ b/Assets/Scripts/Sound/BackgroundMusicOverride.cs
@@ -116,16 +116,17 @@ namespace Frankie.Sound
         public LoadPriority GetLoadPriority() => LoadPriority.ObjectProperty; 
         public SaveState CaptureState() => ManualGetStateFromData(isOverrideActive);
         public void RestoreState(SaveState saveState)
-        {
-            queueTriggerInStart = ManualGetDataFromState(saveState);
+        { 
+            TryManualGetDataFromState(saveState, out queueTriggerInStart);
         }
         
         public SaveState ManualGetStateFromData(bool data) => new(GetLoadPriority(), data);
         
-        public bool ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out bool value)
         {
-            if (saveState == null || !saveState.TryGetState(out bool value)) { return isOverrideActive; }
-            return value;
+            if (saveState != null && saveState.TryGetState(out value)) { return true; }
+            value = isOverrideActive;
+            return false;
         }
         #endregion
     }

--- a/Assets/Scripts/Sound/BackgroundMusicOverride.cs
+++ b/Assets/Scripts/Sound/BackgroundMusicOverride.cs
@@ -35,7 +35,7 @@ namespace Frankie.Sound
             _backgroundMusicOverrides.Remove(backgroundMusicOverride);
         }
 
-        private static bool GetHighestPriorityActiveOverride(out BackgroundMusicOverride highestPriorityOverride)
+        public static bool TryGetHighestPriorityActiveOverride(out BackgroundMusicOverride highestPriorityOverride)
         {
             highestPriorityOverride = null;
             foreach (BackgroundMusicOverride backgroundMusicOverride in _backgroundMusicOverrides.Where(backgroundMusicOverride => backgroundMusicOverride.isOverrideActive))
@@ -55,18 +55,24 @@ namespace Frankie.Sound
 
         private void Start()
         {
-            if (!queueTriggerInStart) return;
-            
-            TriggerOverride(true, true);
+            if (!queueTriggerInStart) { return; }
             queueTriggerInStart = false;
+            
+            BackgroundMusic backgroundMusic = BackgroundMusic.FindBackgroundMusic();
+            if (backgroundMusic == null) { return; }
+            
+            TriggerOverride(true, backgroundMusic);
         }
         #endregion
 
         #region UtilityMethods
         public bool HasAudioOverride() => audioClip != null;
+        public AudioClip GetAudioClip() => audioClip;
         public void TriggerOverride(bool enable) // Callable via Unity Events
         {
-            TriggerOverride(enable, false);
+            BackgroundMusic backgroundMusic = BackgroundMusic.FindBackgroundMusic();
+            if (backgroundMusic == null) { return; }
+            TriggerOverride(enable, backgroundMusic);
         }
 
         public void ToggleOverride() // Callable via Unity Events
@@ -75,20 +81,17 @@ namespace Frankie.Sound
         }
 
         private int GetPriority() => priority;
-        private void TriggerOverride(bool enable, bool calledInRestore)
+        private void TriggerOverride(bool enable, BackgroundMusic backgroundMusic)
         {
-            if (audioClip == null) { return; }
+            if (backgroundMusic == null || audioClip == null) { return; }
             if (enable && _currentBackgroundMusicOverride == this) { return; }
-
-            BackgroundMusic backgroundMusic = BackgroundMusic.FindBackgroundMusic();
-            if (backgroundMusic == null) { return; }
 
             if (enable)
             {
                 isOverrideActive = true;
                 if (_currentBackgroundMusicOverride != null && priority < _currentBackgroundMusicOverride.GetPriority()) { return; }
                 
-                if (backgroundMusic.OverrideMusic(audioClip, calledInRestore))
+                if (backgroundMusic.OverrideMusic(audioClip))
                 {
                     _currentBackgroundMusicOverride = this;
                 }
@@ -96,11 +99,10 @@ namespace Frankie.Sound
             else
             {
                 isOverrideActive = false;
-                
                 if (_currentBackgroundMusicOverride != this) { return; }
                 
                 _currentBackgroundMusicOverride = null;
-                if (GetHighestPriorityActiveOverride(out BackgroundMusicOverride nextUpMusicOverride))
+                if (TryGetHighestPriorityActiveOverride(out BackgroundMusicOverride nextUpMusicOverride))
                 {
                     nextUpMusicOverride.TriggerOverride(true);
                 }

--- a/Assets/Scripts/Speech/AIConversant.cs
+++ b/Assets/Scripts/Speech/AIConversant.cs
@@ -12,7 +12,7 @@ namespace Frankie.Speech
         [SerializeField] private Dialogue dialogue;
         [SerializeField] protected InteractionEvent checkInteraction;
         [SerializeField] private UnityEvent onExitDialogue;
-        [SerializeField] private bool saveDialogueCount = true;
+        [SerializeField] private bool saveDialogueCount = false;
 
         // State
         private int dialogueCount = 0;

--- a/Assets/Scripts/Speech/AIConversant.cs
+++ b/Assets/Scripts/Speech/AIConversant.cs
@@ -2,21 +2,23 @@ using UnityEngine;
 using UnityEngine.Events;
 using Frankie.Control;
 using Frankie.Core.Predicates;
+using Frankie.Saving;
 
 namespace Frankie.Speech
 {
-    public class AIConversant : CheckBase, IPredicateEvaluator
+    public class AIConversant : CheckBase, IPredicateEvaluator, ISaveable<int>
     {
         // Tunables
         [SerializeField] private Dialogue dialogue;
         [SerializeField] protected InteractionEvent checkInteraction;
         [SerializeField] private UnityEvent onExitDialogue;
+        [SerializeField] private bool saveDialogueCount = true;
 
         // State
         private int dialogueCount = 0;
         
         // Cached References
-        PlayerStateMachine playerStateMachine;
+        private PlayerStateMachine playerStateMachine;
 
         #region UnityMethods
         private void Start()
@@ -26,7 +28,6 @@ namespace Frankie.Speech
         #endregion
 
         #region PublicPrivateMethods
-        public Dialogue GetDialogue() => dialogue;
         public int GetDialogueCount() => dialogueCount;
         public void ResetDialogueCount() => dialogueCount = 0;
 
@@ -74,6 +75,39 @@ namespace Frankie.Speech
         {
             var predicateAIConversant = predicate as PredicateAIConversant;
             return predicateAIConversant != null ? predicateAIConversant.Evaluate(this) : null;
+        }
+        
+        // Save Interface (overrides CheckBase)
+        public override SaveState CaptureState() => ManualGetStateFromData(dialogueCount);
+
+        public override void RestoreState(SaveState saveState)
+        {
+            if (!saveDialogueCount) { return; }
+            if (TryManualGetDataFromState(saveState, out int value)) { dialogueCount = value; }
+        }
+
+        public SaveState ManualGetStateFromData(int data)
+        {
+            if (!saveDialogueCount) { return null; }
+            
+            if (data < 0) { data = dialogueCount; }
+            return new SaveState(GetLoadPriority(), data);
+        }
+
+        public bool TryManualGetDataFromState(SaveState saveState, out int value)
+        {
+            if (!saveDialogueCount) { value = 0; return false; }
+            
+            // Save Found Pass Back
+            if (saveState != null && saveState.TryGetState(out value))
+            {
+                value = value >= 0 ? value : dialogueCount;
+                return true;
+            }
+            
+            // Default Pass Back
+            value = dialogueCount;
+            return saveDialogueCount;
         }
         #endregion
     }

--- a/Assets/Scripts/Stats/BaseStats.cs
+++ b/Assets/Scripts/Stats/BaseStats.cs
@@ -219,15 +219,20 @@ namespace Frankie.Stats
         
         public SaveState ManualGetStateFromData(BaseStatsSaveData data) => new(GetLoadPriority(), data);
         
-        public BaseStatsSaveData ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out BaseStatsSaveData baseStatsSaveData)
         {
-            if (!saveBaseStats) { return null; }
-            if (progression == null || characterProperties == null || !progression.HasProgression(characterProperties)) { return null; }
-            if (saveState != null && saveState.TryGetState(out BaseStatsSaveData baseStatsSaveData)) { return baseStatsSaveData; }
+            baseStatsSaveData = null;
+            if (!saveBaseStats) { return false; }
+            if (progression == null || characterProperties == null || !progression.HasProgression(characterProperties)) { return false; }
             
+            // Success Pass Back
+            if (saveState != null && saveState.TryGetState(out baseStatsSaveData)) { return true; }
+            
+            // Default Pass Back
             Dictionary<Stat, float> statSheet = progression.GetStatSheet(characterProperties);
             int initialLevel = statSheet.TryGetValue(Stat.InitialLevel, out var value) ? (int)value : 1;
-            return new BaseStatsSaveData(initialLevel, statSheet);
+            baseStatsSaveData = new BaseStatsSaveData(initialLevel, statSheet);
+            return false;
         }
         #endregion
     }

--- a/Assets/Scripts/Stats/BaseStats.cs
+++ b/Assets/Scripts/Stats/BaseStats.cs
@@ -210,7 +210,7 @@ namespace Frankie.Stats
         public void RestoreState(SaveState saveState)
         {
             if (!saveBaseStats) { return; }
-            if (saveState.GetState(typeof(BaseStatsSaveData)) is not BaseStatsSaveData baseStatsSaveData) { return; }
+            if (saveState == null || !saveState.TryGetState(out BaseStatsSaveData baseStatsSaveData)) { return; }
 
             currentLevel ??= new LazyValue<int>(GetInitialLevel);
             currentLevel.value = baseStatsSaveData.level;
@@ -221,9 +221,9 @@ namespace Frankie.Stats
         
         public BaseStatsSaveData ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState?.GetState(typeof(BaseStatsSaveData)) is BaseStatsSaveData baseStatsSaveData) { return baseStatsSaveData; }
             if (!saveBaseStats) { return null; }
             if (progression == null || characterProperties == null || !progression.HasProgression(characterProperties)) { return null; }
+            if (saveState != null && saveState.TryGetState(out BaseStatsSaveData baseStatsSaveData)) { return baseStatsSaveData; }
             
             Dictionary<Stat, float> statSheet = progression.GetStatSheet(characterProperties);
             int initialLevel = statSheet.TryGetValue(Stat.InitialLevel, out var value) ? (int)value : 1;

--- a/Assets/Scripts/Stats/BaseStats.cs
+++ b/Assets/Scripts/Stats/BaseStats.cs
@@ -225,14 +225,14 @@ namespace Frankie.Stats
             if (!saveBaseStats) { return false; }
             if (progression == null || characterProperties == null || !progression.HasProgression(characterProperties)) { return false; }
             
-            // Success Pass Back
-            if (saveState != null && saveState.TryGetState(out baseStatsSaveData)) { return true; }
+            // Save Found Pass Back
+            if (saveState != null && saveState.TryGetState(out baseStatsSaveData) &&  baseStatsSaveData.statSheet != null) { return true; }
             
             // Default Pass Back
             Dictionary<Stat, float> statSheet = progression.GetStatSheet(characterProperties);
             int initialLevel = statSheet.TryGetValue(Stat.InitialLevel, out var value) ? (int)value : 1;
             baseStatsSaveData = new BaseStatsSaveData(initialLevel, statSheet);
-            return false;
+            return true;
         }
         #endregion
     }

--- a/Assets/Scripts/Stats/Experience.cs
+++ b/Assets/Scripts/Stats/Experience.cs
@@ -91,7 +91,7 @@ namespace Frankie.Stats
         public void RestoreState(SaveState saveState)
         {
             currentPoints ??= new LazyValue<float>(GetInitialPoints);
-            currentPoints.value = ManualGetDataFromState(saveState);
+            if (TryManualGetDataFromState(saveState, out float value)) { currentPoints.value = value; }
         }
         
         public SaveState ManualGetStateFromData(float data)
@@ -100,10 +100,16 @@ namespace Frankie.Stats
             return new SaveState(GetLoadPriority(), data);
         }
 
-        public float ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out float value)
         {
-            if (saveState == null || !saveState.TryGetState(out float value)) { return initialPoints; }
-            return value >= 0 ? value : initialPoints;
+            if (saveState != null && saveState.TryGetState(out value))
+            {
+                value = value >= 0 ? value : initialPoints;
+                return true;
+            }
+            
+            value = initialPoints;
+            return false;
         }
         #endregion
     }

--- a/Assets/Scripts/Stats/Experience.cs
+++ b/Assets/Scripts/Stats/Experience.cs
@@ -102,8 +102,8 @@ namespace Frankie.Stats
 
         public float ManualGetDataFromState(SaveState saveState)
         {
-            float points = saveState != null ? (float)saveState.GetState(typeof(float)) : initialPoints;
-            return points >= 0 ? points : initialPoints;
+            if (saveState == null || !saveState.TryGetState(out float value)) { return initialPoints; }
+            return value >= 0 ? value : initialPoints;
         }
         #endregion
     }

--- a/Assets/Scripts/Stats/Party/InactiveParty.cs
+++ b/Assets/Scripts/Stats/Party/InactiveParty.cs
@@ -49,7 +49,8 @@ namespace Frankie.Stats
 
         public void RestoreState(SaveState saveState)
         {
-            foreach (CharacterProperties characterProperties in ManualGetDataFromState(saveState))
+            if (!TryManualGetDataFromState(saveState, out HashSet<CharacterProperties> data)) { return; }
+            foreach (CharacterProperties characterProperties in data)
             {
                 inactiveCharacters.Add(characterProperties);
             }
@@ -62,10 +63,13 @@ namespace Frankie.Stats
             return new SaveState(GetLoadPriority(), partyNames);
         }
 
-        public HashSet<CharacterProperties> ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out HashSet<CharacterProperties> data)
         {
-            if (saveState == null || !saveState.TryGetState(out List<string> partyNames)) { return new HashSet<CharacterProperties>(); }
-            return partyNames.Select(CharacterProperties.GetCharacterPropertiesFromName).Where(partyCharacter => partyCharacter != null).ToHashSet();
+            data = new HashSet<CharacterProperties>();
+            if (saveState == null || !saveState.TryGetState(out List<string> partyNames)) { return false; }
+            
+            data = partyNames.Select(CharacterProperties.GetCharacterPropertiesFromName).Where(partyCharacter => partyCharacter != null).ToHashSet();
+            return true;
         }
         #endregion
     }

--- a/Assets/Scripts/Stats/Party/InactiveParty.cs
+++ b/Assets/Scripts/Stats/Party/InactiveParty.cs
@@ -64,7 +64,7 @@ namespace Frankie.Stats
 
         public HashSet<CharacterProperties> ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState?.GetState(typeof(List<string>)) is not List<string> partyNames) { return new HashSet<CharacterProperties>(); }
+            if (saveState == null || !saveState.TryGetState(out List<string> partyNames)) { return new HashSet<CharacterProperties>(); }
             return partyNames.Select(CharacterProperties.GetCharacterPropertiesFromName).Where(partyCharacter => partyCharacter != null).ToHashSet();
         }
         #endregion

--- a/Assets/Scripts/Stats/Party/InactiveParty.cs
+++ b/Assets/Scripts/Stats/Party/InactiveParty.cs
@@ -66,8 +66,10 @@ namespace Frankie.Stats
         public bool TryManualGetDataFromState(SaveState saveState, out HashSet<CharacterProperties> data)
         {
             data = new HashSet<CharacterProperties>();
-            if (saveState == null || !saveState.TryGetState(out List<string> partyNames)) { return false; }
+            // Default Pass Back
+            if (saveState == null || !saveState.TryGetState(out List<string> partyNames)) { return true; }
             
+            // Save Found Pass Back
             data = partyNames.Select(CharacterProperties.GetCharacterPropertiesFromName).Where(partyCharacter => partyCharacter != null).ToHashSet();
             return true;
         }

--- a/Assets/Scripts/Stats/Party/Party.cs
+++ b/Assets/Scripts/Stats/Party/Party.cs
@@ -331,10 +331,13 @@ namespace Frankie.Stats
             return new SaveState(GetLoadPriority(), partySerializableSaveData);
         }
 
-        public PartySaveData ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out PartySaveData data)
         {
-            if (saveState != null && saveState.TryGetState(out PartySerializableSaveData partySerializableSaveData)) { return UnpackPartySerializableSaveData(partySerializableSaveData); }
-            return new PartySaveData();
+            data = new PartySaveData();
+            if (saveState == null || !saveState.TryGetState(out PartySerializableSaveData partySerializableSaveData)) { return false; }
+            
+            data = UnpackPartySerializableSaveData(partySerializableSaveData);
+            return true;
         }
         
         private static PartySaveData UnpackPartySerializableSaveData(PartySerializableSaveData partySerializableSaveData)

--- a/Assets/Scripts/Stats/Party/Party.cs
+++ b/Assets/Scripts/Stats/Party/Party.cs
@@ -310,7 +310,7 @@ namespace Frankie.Stats
 
         public void RestoreState(SaveState saveState)
         {
-            if (saveState.GetState(typeof(PartySerializableSaveData)) is not PartySerializableSaveData partySerializableSaveData) { return; }
+            if (saveState == null || !saveState.TryGetState(out PartySerializableSaveData partySerializableSaveData)) { return; }
             PartySaveData partySaveData = UnpackPartySerializableSaveData(partySerializableSaveData);
 
             RestorePartyMembers(partySaveData.partyCharacters);
@@ -333,7 +333,8 @@ namespace Frankie.Stats
 
         public PartySaveData ManualGetDataFromState(SaveState saveState)
         {
-            return saveState?.GetState(typeof(PartySerializableSaveData)) is PartySerializableSaveData partySerializableSaveData ? UnpackPartySerializableSaveData(partySerializableSaveData) : new PartySaveData();
+            if (saveState != null && saveState.TryGetState(out PartySerializableSaveData partySerializableSaveData)) { return UnpackPartySerializableSaveData(partySerializableSaveData); }
+            return new PartySaveData();
         }
         
         private static PartySaveData UnpackPartySerializableSaveData(PartySerializableSaveData partySerializableSaveData)

--- a/Assets/Scripts/Stats/Party/Party.cs
+++ b/Assets/Scripts/Stats/Party/Party.cs
@@ -334,8 +334,10 @@ namespace Frankie.Stats
         public bool TryManualGetDataFromState(SaveState saveState, out PartySaveData data)
         {
             data = new PartySaveData();
-            if (saveState == null || !saveState.TryGetState(out PartySerializableSaveData partySerializableSaveData)) { return false; }
+            // Default Pass Back
+            if (saveState == null || !saveState.TryGetState(out PartySerializableSaveData partySerializableSaveData)) { return true; }
             
+            // Save Found Pass Back
             data = UnpackPartySerializableSaveData(partySerializableSaveData);
             return true;
         }

--- a/Assets/Scripts/Stats/Party/PartyAssist.cs
+++ b/Assets/Scripts/Stats/Party/PartyAssist.cs
@@ -127,8 +127,10 @@ namespace Frankie.Stats
         public bool TryManualGetDataFromState(SaveState saveState, out HashSet<CharacterProperties> data)
         {
             data = new HashSet<CharacterProperties>();
-            if (saveState == null || !saveState.TryGetState(out List<string> partyNames)) { return false; }
+            // Default Pass Back
+            if (saveState == null || !saveState.TryGetState(out List<string> partyNames)) { return true; }
             
+            // Save Found Pass Back
             data = partyNames.Select(CharacterProperties.GetCharacterPropertiesFromName).Where(partyCharacter => partyCharacter != null).ToHashSet();
             return true;
         }

--- a/Assets/Scripts/Stats/Party/PartyAssist.cs
+++ b/Assets/Scripts/Stats/Party/PartyAssist.cs
@@ -113,7 +113,7 @@ namespace Frankie.Stats
 
         public void RestoreState(SaveState saveState)
         {
-            HashSet<CharacterProperties> partyCharacters = ManualGetDataFromState(saveState);
+            if (!TryManualGetDataFromState(saveState, out HashSet<CharacterProperties> partyCharacters)) { return; }
             RestorePartyMembers(partyCharacters);
         }
         
@@ -124,10 +124,13 @@ namespace Frankie.Stats
             return new SaveState(GetLoadPriority(), partyNames);
         }
 
-        public HashSet<CharacterProperties> ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out HashSet<CharacterProperties> data)
         {
-            if (saveState == null || !saveState.TryGetState(out List<string> partyNames)) { return new HashSet<CharacterProperties>(); }
-            return partyNames.Select(CharacterProperties.GetCharacterPropertiesFromName).Where(partyCharacter => partyCharacter != null).ToHashSet();
+            data = new HashSet<CharacterProperties>();
+            if (saveState == null || !saveState.TryGetState(out List<string> partyNames)) { return false; }
+            
+            data = partyNames.Select(CharacterProperties.GetCharacterPropertiesFromName).Where(partyCharacter => partyCharacter != null).ToHashSet();
+            return true;
         }
         
         private void RestorePartyMembers(HashSet<CharacterProperties> partyCharacters)

--- a/Assets/Scripts/Stats/Party/PartyAssist.cs
+++ b/Assets/Scripts/Stats/Party/PartyAssist.cs
@@ -126,7 +126,7 @@ namespace Frankie.Stats
 
         public HashSet<CharacterProperties> ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState?.GetState(typeof(List<string>)) is not List<string> partyNames) { return new HashSet<CharacterProperties>(); }
+            if (saveState == null || !saveState.TryGetState(out List<string> partyNames)) { return new HashSet<CharacterProperties>(); }
             return partyNames.Select(CharacterProperties.GetCharacterPropertiesFromName).Where(partyCharacter => partyCharacter != null).ToHashSet();
         }
         

--- a/Assets/Scripts/Utils/DataStructuresExtensions/JTokenExtensions.cs
+++ b/Assets/Scripts/Utils/DataStructuresExtensions/JTokenExtensions.cs
@@ -1,0 +1,53 @@
+using Newtonsoft.Json.Linq;
+
+namespace Frankie.Utils
+{
+    public static class JTokenExtensions
+    {
+
+        public static bool TryToObject<T>(this JToken token, out T value)
+        {
+            // Note:  Null entries return false, which is expected behaviour for this save system
+            // i.e. we do not allow saving null state, it is effectively ignored (defaults used via RestoreState)
+            if (token is null || token.Type == JTokenType.Null || token.Type == JTokenType.Undefined)
+            {
+                value = default;
+                return false;
+            }
+            
+            if (token is JValue jValue)
+            {
+                // Exact match:  no conversion needed
+                if (jValue.Value is T exact)
+                {
+                    value = exact;
+                    return true;
+                }
+
+                try
+                {
+                    // Scalar conversion:  numeric widening/narrowing, string<->enum, Guid,  etc.
+                    value = jValue.Value<T>();
+                    return value != null;
+                }
+                catch
+                {
+                    value = default;
+                    return false;
+                }
+            }
+
+            // Slow path:  objects/arrays use the full serializer
+            try
+            {
+                value = token.ToObject<T>();
+                return value != null;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Utils/DataStructuresExtensions/JTokenExtensions.cs
+++ b/Assets/Scripts/Utils/DataStructuresExtensions/JTokenExtensions.cs
@@ -49,5 +49,25 @@ namespace Frankie.Utils
                 return false;
             }
         }
+        
+        public static bool IsNullOrEmpty(this JToken token)
+        {
+            if (token == null)
+                return true;
+
+            switch (token.Type)
+            {
+                case JTokenType.Null:
+                case JTokenType.Undefined:
+                    return true;
+                case JTokenType.Array:
+                case JTokenType.Object:
+                    return !token.HasValues;
+                case JTokenType.String:
+                    return string.IsNullOrEmpty(token.ToString());
+                default:
+                    return false;
+            }
+        }
     }
 }

--- a/Assets/Scripts/Utils/DataStructuresExtensions/JTokenExtensions.cs.meta
+++ b/Assets/Scripts/Utils/DataStructuresExtensions/JTokenExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 992dab318f4c41cda38f1b31cd137d6b
+timeCreated: 1783615450

--- a/Assets/Scripts/Utils/DataStructuresExtensions/JTokenExtensions.cs.meta
+++ b/Assets/Scripts/Utils/DataStructuresExtensions/JTokenExtensions.cs.meta
@@ -1,3 +1,11 @@
 fileFormatVersion: 2
 guid: 992dab318f4c41cda38f1b31cd137d6b
-timeCreated: 1783615450
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/World/Core/FlickerOverlay.cs
+++ b/Assets/Scripts/World/Core/FlickerOverlay.cs
@@ -96,8 +96,8 @@ namespace Frankie.World
         
         public bool ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState == null) { return childrenEnabled; }
-            return (bool)saveState.GetState(typeof(bool));
+            if (saveState == null || !saveState.TryGetState(out bool value)) { return childrenEnabled; }
+            return value;
         }
         #endregion
     }

--- a/Assets/Scripts/World/Core/FlickerOverlay.cs
+++ b/Assets/Scripts/World/Core/FlickerOverlay.cs
@@ -98,7 +98,7 @@ namespace Frankie.World
         {
             if (saveState != null && saveState.TryGetState(out value)) { return true; }
             value = childrenEnabled;
-            return false;
+            return true;
         }
         #endregion
     }

--- a/Assets/Scripts/World/Core/FlickerOverlay.cs
+++ b/Assets/Scripts/World/Core/FlickerOverlay.cs
@@ -88,16 +88,17 @@ namespace Frankie.World
 
         public void RestoreState(SaveState saveState)
         {
-            childrenEnabled = ManualGetDataFromState(saveState);
+            TryManualGetDataFromState(saveState, out childrenEnabled);
             foreach (Transform child in transform) { child.gameObject.SetActive(childrenEnabled); }
         }
         
         public SaveState ManualGetStateFromData(bool data) => new(GetLoadPriority(), data);
         
-        public bool ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out bool value)
         {
-            if (saveState == null || !saveState.TryGetState(out bool value)) { return childrenEnabled; }
-            return value;
+            if (saveState != null && saveState.TryGetState(out value)) { return true; }
+            value = childrenEnabled;
+            return false;
         }
         #endregion
     }

--- a/Assets/Scripts/World/Inventory/WorldCashGiverTaker.cs
+++ b/Assets/Scripts/World/Inventory/WorldCashGiverTaker.cs
@@ -145,8 +145,8 @@ namespace Frankie.World
 
         public int ManualGetDataFromState(SaveState saveState)
         {
-            int data = saveState != null ? (int)saveState.GetState(typeof(int)) : GetInitialTransactionCount();
-            return data >= 0 ? data : GetInitialTransactionCount();
+            if (saveState == null || !saveState.TryGetState(out int value)) { return GetInitialTransactionCount(); }
+            return value >= 0 ? value : GetInitialTransactionCount();
         }
     }
 }

--- a/Assets/Scripts/World/Inventory/WorldCashGiverTaker.cs
+++ b/Assets/Scripts/World/Inventory/WorldCashGiverTaker.cs
@@ -133,7 +133,7 @@ namespace Frankie.World
         public void RestoreState(SaveState saveState)
         {
             numberTransactionsLeft ??= new LazyValue<int>(GetInitialTransactionCount);
-            numberTransactionsLeft.value = ManualGetDataFromState(saveState);
+            if (TryManualGetDataFromState(saveState, out int value)) { numberTransactionsLeft.value = value; }
         }
         #endregion
 
@@ -143,10 +143,15 @@ namespace Frankie.World
             return new SaveState(GetLoadPriority(), data);
         }
 
-        public int ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out int value)
         {
-            if (saveState == null || !saveState.TryGetState(out int value)) { return GetInitialTransactionCount(); }
-            return value >= 0 ? value : GetInitialTransactionCount();
+            if (saveState != null && saveState.TryGetState(out value))
+            {
+                value = value >= 0 ? value : GetInitialTransactionCount();
+                return true;
+            }
+            value = GetInitialTransactionCount();
+            return false;
         }
     }
 }

--- a/Assets/Scripts/World/Inventory/WorldCashGiverTaker.cs
+++ b/Assets/Scripts/World/Inventory/WorldCashGiverTaker.cs
@@ -151,7 +151,7 @@ namespace Frankie.World
                 return true;
             }
             value = GetInitialTransactionCount();
-            return false;
+            return true;
         }
     }
 }

--- a/Assets/Scripts/World/Inventory/WorldItemGiverTaker.cs
+++ b/Assets/Scripts/World/Inventory/WorldItemGiverTaker.cs
@@ -149,7 +149,7 @@ namespace Frankie.World
         public void RestoreState(SaveState state)
         {
             currentItemQuantity ??= new LazyValue<int>(GetMaxItemQuantity);
-            currentItemQuantity.value = ManualGetDataFromState(state);
+            if (TryManualGetDataFromState(state, out int value)) { currentItemQuantity.value = value; }
         }
         
         public SaveState ManualGetStateFromData(int data)
@@ -158,10 +158,15 @@ namespace Frankie.World
             return new SaveState(GetLoadPriority(), data);
         }
 
-        public int ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out int value)
         {
-            if (saveState == null || !saveState.TryGetState(out int value)) { return GetMaxItemQuantity(); }
-            return value >= 0 ? value : GetMaxItemQuantity();
+            if (saveState != null && saveState.TryGetState(out value))
+            {
+                value = value >= 0 ? value : GetMaxItemQuantity();
+                return true;
+            }
+            value = GetMaxItemQuantity();
+            return false;
         }
         #endregion
     }

--- a/Assets/Scripts/World/Inventory/WorldItemGiverTaker.cs
+++ b/Assets/Scripts/World/Inventory/WorldItemGiverTaker.cs
@@ -166,7 +166,7 @@ namespace Frankie.World
                 return true;
             }
             value = GetMaxItemQuantity();
-            return false;
+            return true;
         }
         #endregion
     }

--- a/Assets/Scripts/World/Inventory/WorldItemGiverTaker.cs
+++ b/Assets/Scripts/World/Inventory/WorldItemGiverTaker.cs
@@ -160,8 +160,8 @@ namespace Frankie.World
 
         public int ManualGetDataFromState(SaveState saveState)
         {
-            int data = saveState != null ? (int)saveState.GetState(typeof(int)) : GetMaxItemQuantity();
-            return data >= 0 ? data : GetMaxItemQuantity();
+            if (saveState == null || !saveState.TryGetState(out int value)) { return GetMaxItemQuantity(); }
+            return value >= 0 ? value : GetMaxItemQuantity();
         }
         #endregion
     }

--- a/Assets/Scripts/World/StatsProperties/WorldSpriteChanger.cs
+++ b/Assets/Scripts/World/StatsProperties/WorldSpriteChanger.cs
@@ -58,16 +58,17 @@ namespace Frankie.World
 
         public void RestoreState(SaveState saveState)
         {
-            isAlternateSprite = ManualGetDataFromState(saveState);
+            TryManualGetDataFromState(saveState, out isAlternateSprite);
             UpdateSprite();
         }
         
         public SaveState ManualGetStateFromData(bool data) => new(GetLoadPriority(), data);
 
-        public bool ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out bool value)
         {
-            if (saveState == null || !saveState.TryGetState(out bool value)) { return isAlternateSprite; }
-            return value;
+            if (saveState != null && saveState.TryGetState(out value)) { return true; }
+            value = isAlternateSprite;
+            return false;
         }
         #endregion
     }

--- a/Assets/Scripts/World/StatsProperties/WorldSpriteChanger.cs
+++ b/Assets/Scripts/World/StatsProperties/WorldSpriteChanger.cs
@@ -66,8 +66,8 @@ namespace Frankie.World
 
         public bool ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState == null) { return isAlternateSprite; }
-            return (bool)saveState.GetState(typeof(bool));
+            if (saveState == null || !saveState.TryGetState(out bool value)) { return isAlternateSprite; }
+            return value;
         }
         #endregion
     }

--- a/Assets/Scripts/World/StatsProperties/WorldSpriteChanger.cs
+++ b/Assets/Scripts/World/StatsProperties/WorldSpriteChanger.cs
@@ -68,7 +68,7 @@ namespace Frankie.World
         {
             if (saveState != null && saveState.TryGetState(out value)) { return true; }
             value = isAlternateSprite;
-            return false;
+            return true;
         }
         #endregion
     }

--- a/Assets/Scripts/Zones/Room.cs
+++ b/Assets/Scripts/Zones/Room.cs
@@ -68,7 +68,7 @@ namespace Frankie.ZoneManagement
         public void RestoreState(SaveState saveState)
         {
             if (saveState == null) { return; }
-            bool roomEnabled = ManualGetDataFromState(saveState);
+            TryManualGetDataFromState(saveState, out bool roomEnabled);
             
             InitializeRoom();
             ToggleRoom(roomEnabled, true);
@@ -76,10 +76,11 @@ namespace Frankie.ZoneManagement
         
         public SaveState ManualGetStateFromData(bool data) => new(GetLoadPriority(), data);
         
-        public bool ManualGetDataFromState(SaveState saveState)
+        public bool TryManualGetDataFromState(SaveState saveState, out bool value)
         {
-            if (saveState == null || !saveState.TryGetState(out bool value)) { return isRoomActive; }
-            return value;
+            if (saveState != null && saveState.TryGetState(out value)) { return true; }
+            value = isRoomActive;
+            return false;
         }
         #endregion
     }

--- a/Assets/Scripts/Zones/Room.cs
+++ b/Assets/Scripts/Zones/Room.cs
@@ -78,8 +78,8 @@ namespace Frankie.ZoneManagement
         
         public bool ManualGetDataFromState(SaveState saveState)
         {
-            if (saveState == null) { return isRoomActive; }
-            return (bool)saveState.GetState(typeof(bool));
+            if (saveState == null || !saveState.TryGetState(out bool value)) { return isRoomActive; }
+            return value;
         }
         #endregion
     }

--- a/Assets/Scripts/Zones/Room.cs
+++ b/Assets/Scripts/Zones/Room.cs
@@ -80,7 +80,7 @@ namespace Frankie.ZoneManagement
         {
             if (saveState != null && saveState.TryGetState(out value)) { return true; }
             value = isRoomActive;
-            return false;
+            return true;
         }
         #endregion
     }


### PR DESCRIPTION
## Issue
We're using JToken.ToObject() which can throw error if cannot box properly, should do this more safely.

## Solution Space
Should:
* check if a primitive / JValue type, and use .Value (as possible) -> .Value<T>() (otherwise)
* if non-primitive, then use .ToObject<T>() in a try / catch

## Bonus
Additional improvements while we're here:
* Update the ManualGetData signature for ISaveable<T> (to avoid ugliness when overriding ISaveable<T1> from parent to ISaveable<T2> for child)
* Make AIConversant saveable -- save number of times chatted, for use in one-off dialogue runs