### PR TITLE
CU-32b9hbu :: Add predicate evaluation for party assist characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,7 +117,6 @@ Assets/UnityConfigurables/AddressableAssetsData/link.xml
 Assets/UnityConfigurables/AddressableAssetsData/link.xml.meta
 Assets/z_MadeAssets/
 Assets/z_ImportedAssets/
-Assets/Game/Speech/z_Debug
 InfoTools/TilemapPacking/Input/
 InfoTools/TilemapPacking/Output/
 InfoTools/TilemapPacking/__pycache__/

--- a/Assets/Game/Predicates/Party/ContainsPhilRamen.asset
+++ b/Assets/Game/Predicates/Party/ContainsPhilRamen.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: edca8e3104345164fb529398740edfe1, type: 3}
+  m_Name: ContainsPhilRamen
+  m_EditorClassIdentifier: Assembly-CSharp::Frankie.Core.Predicates.AnyCharacterInPartyPredicate
+  partyBehaviourType: 1
+  charactersToMatch:
+  - {fileID: 11400000, guid: e97120b87e74eee4f9d9d8659f0bddf5, type: 2}

--- a/Assets/Game/Predicates/Party/ContainsPhilRamen.asset.meta
+++ b/Assets/Game/Predicates/Party/ContainsPhilRamen.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a8eed3b6a86bb41cbbcaa4e7f78633d8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Speech/z_Debug/DebugSpeech.asset
+++ b/Assets/Game/Speech/z_Debug/DebugSpeech.asset
@@ -1,0 +1,383 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-439491334927249621
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c07c7c6f4c666429a0bbc8d18232b2, type: 3}
+  m_Name: cc511da4-4c83-4a78-b373-1b48adc39b29
+  m_EditorClassIdentifier: Assembly-CSharp::Frankie.Speech.DialogueNode
+  dialogueName: DebugSpeech
+  speakerType: 1
+  characterProperties: {fileID: 0}
+  localizedSpeakerName:
+    m_TableReference:
+      m_TableCollectionName: GUID:991c04154cea34203a64a5fe4f5e097e
+    m_TableEntryReference:
+      m_KeyId: 29385017456058368
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  localizedText:
+    m_TableReference:
+      m_TableCollectionName: GUID:991c04154cea34203a64a5fe4f5e097e
+    m_TableEntryReference:
+      m_KeyId: 29385017690939392
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  nodeDepth: 2
+  nodeBreadth: 1
+  children: []
+  rect:
+    serializedVersion: 2
+    x: 1069
+    y: 257
+    width: 400
+    height: 225
+  draggingRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 400
+    height: 45
+  condition:
+    and:
+    - or:
+      - predicate: {fileID: 11400000, guid: 0371ffefc940963478cb27ead3e1e75b, type: 2}
+        negate: 1
+  cachedSpeakerName: Echo2
+  cachedText: Good Job There
+  references:
+    version: 2
+    RefIds: []
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aac27b8e802ced743b3f275e283ab9df, type: 3}
+  m_Name: DebugSpeech
+  m_EditorClassIdentifier: Assembly-CSharp::Frankie.Speech.Dialogue
+  skipRootNode: 0
+  cachedName: DebugSpeech
+  newNodeOffset: {x: 100, y: 25}
+  nodeWidth: 400
+  nodeHeight: 225
+  activeNPCs: []
+  dialogueNodes:
+  - {fileID: 831103004782998081}
+  - {fileID: 1327171722743843887}
+  - {fileID: 7042545445421715153}
+  - {fileID: 3972614220069180872}
+  - {fileID: -439491334927249621}
+  - {fileID: 4102048742459345007}
+--- !u!114 &831103004782998081
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c07c7c6f4c666429a0bbc8d18232b2, type: 3}
+  m_Name: 3e3c78f4-598f-41e1-b85d-04bd70f74972
+  m_EditorClassIdentifier: Assembly-CSharp::Frankie.Speech.DialogueNode
+  dialogueName: DebugSpeech
+  speakerType: 1
+  characterProperties: {fileID: 0}
+  localizedSpeakerName:
+    m_TableReference:
+      m_TableCollectionName: GUID:991c04154cea34203a64a5fe4f5e097e
+    m_TableEntryReference:
+      m_KeyId: 29385112645787648
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  localizedText:
+    m_TableReference:
+      m_TableCollectionName: GUID:991c04154cea34203a64a5fe4f5e097e
+    m_TableEntryReference:
+      m_KeyId: 29263639864139776
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  nodeDepth: 0
+  nodeBreadth: 0
+  children:
+  - 68fbc89f-9516-48b7-9484-a12b0b96109d
+  - 511af9c4-d35f-4251-a13f-274f5d91aa68
+  rect:
+    serializedVersion: 2
+    x: 22
+    y: 22
+    width: 400
+    height: 225
+  draggingRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 400
+    height: 45
+  condition:
+    and: []
+  cachedSpeakerName: Jones
+  cachedText: 'This is a test if \n newline characters will work \n or how they
+
+    should
+    be
+
+    formatted?'
+  references:
+    version: 2
+    RefIds: []
+--- !u!114 &1327171722743843887
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c07c7c6f4c666429a0bbc8d18232b2, type: 3}
+  m_Name: 68fbc89f-9516-48b7-9484-a12b0b96109d
+  m_EditorClassIdentifier: Assembly-CSharp::Frankie.Speech.DialogueNode
+  dialogueName: DebugSpeech
+  speakerType: 0
+  characterProperties: {fileID: 0}
+  localizedSpeakerName:
+    m_TableReference:
+      m_TableCollectionName: GUID:991c04154cea34203a64a5fe4f5e097e
+    m_TableEntryReference:
+      m_KeyId: 29263053001318400
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  localizedText:
+    m_TableReference:
+      m_TableCollectionName: GUID:991c04154cea34203a64a5fe4f5e097e
+    m_TableEntryReference:
+      m_KeyId: 29263053328474112
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  nodeDepth: 1
+  nodeBreadth: 0
+  children:
+  - 7c6b845f-867c-497b-a0c6-b3301000100b
+  rect:
+    serializedVersion: 2
+    x: 505
+    y: 4
+    width: 400
+    height: 225
+  draggingRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 400
+    height: 45
+  condition:
+    and:
+    - or:
+      - predicate: {fileID: 11400000, guid: 3254953458e7313408e640d321e10285, type: 2}
+        negate: 0
+  cachedSpeakerName: DefaultSpeaker
+  cachedText: OK, thanks \n bud
+  references:
+    version: 2
+    RefIds: []
+--- !u!114 &3972614220069180872
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c07c7c6f4c666429a0bbc8d18232b2, type: 3}
+  m_Name: 511af9c4-d35f-4251-a13f-274f5d91aa68
+  m_EditorClassIdentifier: Assembly-CSharp::Frankie.Speech.DialogueNode
+  dialogueName: DebugSpeech
+  speakerType: 0
+  characterProperties: {fileID: 0}
+  localizedSpeakerName:
+    m_TableReference:
+      m_TableCollectionName: GUID:991c04154cea34203a64a5fe4f5e097e
+    m_TableEntryReference:
+      m_KeyId: 29384982865633280
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  localizedText:
+    m_TableReference:
+      m_TableCollectionName: GUID:991c04154cea34203a64a5fe4f5e097e
+    m_TableEntryReference:
+      m_KeyId: 29384983293452288
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  nodeDepth: 1
+  nodeBreadth: 1
+  children:
+  - cc511da4-4c83-4a78-b373-1b48adc39b29
+  - 7c6b845f-867c-497b-a0c6-b3301000100b
+  rect:
+    serializedVersion: 2
+    x: 488.38687
+    y: 302.1435
+    width: 400
+    height: 225
+  draggingRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 400
+    height: 45
+  condition:
+    and:
+    - or:
+      - predicate: {fileID: 11400000, guid: a7bbc4f4f2f05314088fea20cb40007e, type: 2}
+        negate: 0
+  cachedSpeakerName: DefaultSpeaker
+  cachedText: "Hello Moto\t"
+  references:
+    version: 2
+    RefIds: []
+--- !u!114 &4102048742459345007
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c07c7c6f4c666429a0bbc8d18232b2, type: 3}
+  m_Name: fa51ca51-ba23-41e4-a42e-75b1c8e1b034
+  m_EditorClassIdentifier: Assembly-CSharp::Frankie.Speech.DialogueNode
+  dialogueName: DebugSpeech
+  speakerType: 0
+  characterProperties: {fileID: 0}
+  localizedSpeakerName:
+    m_TableReference:
+      m_TableCollectionName: GUID:991c04154cea34203a64a5fe4f5e097e
+    m_TableEntryReference:
+      m_KeyId: 29784862041825280
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  localizedText:
+    m_TableReference:
+      m_TableCollectionName: GUID:991c04154cea34203a64a5fe4f5e097e
+    m_TableEntryReference:
+      m_KeyId: 29784862696136704
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  nodeDepth: 3
+  nodeBreadth: 0
+  children: []
+  rect:
+    serializedVersion: 2
+    x: 1530
+    y: 30
+    width: 400
+    height: 225
+  draggingRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 400
+    height: 45
+  condition:
+    and:
+    - or:
+      - predicate: {fileID: 11400000, guid: a8eed3b6a86bb41cbbcaa4e7f78633d8, type: 2}
+        negate: 0
+  cachedSpeakerName: DefaultSpeaker
+  cachedText: Here we go again
+  references:
+    version: 2
+    RefIds: []
+--- !u!114 &7042545445421715153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c07c7c6f4c666429a0bbc8d18232b2, type: 3}
+  m_Name: 7c6b845f-867c-497b-a0c6-b3301000100b
+  m_EditorClassIdentifier: Assembly-CSharp::Frankie.Speech.DialogueNode
+  dialogueName: DebugSpeech
+  speakerType: 1
+  characterProperties: {fileID: 0}
+  localizedSpeakerName:
+    m_TableReference:
+      m_TableCollectionName: GUID:991c04154cea34203a64a5fe4f5e097e
+    m_TableEntryReference:
+      m_KeyId: 29279002790191104
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  localizedText:
+    m_TableReference:
+      m_TableCollectionName: GUID:991c04154cea34203a64a5fe4f5e097e
+    m_TableEntryReference:
+      m_KeyId: 29279003046043648
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  nodeDepth: 2
+  nodeBreadth: 0
+  children:
+  - fa51ca51-ba23-41e4-a42e-75b1c8e1b034
+  rect:
+    serializedVersion: 2
+    x: 1030
+    y: 30
+    width: 400
+    height: 225
+  draggingRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 400
+    height: 45
+  condition:
+    and:
+    - or:
+      - predicate: {fileID: 11400000, guid: 0371ffefc940963478cb27ead3e1e75b, type: 2}
+        negate: 0
+  cachedSpeakerName: Jones
+  cachedText: Temp123
+  references:
+    version: 2
+    RefIds: []

--- a/Assets/Game/Speech/z_Debug/DebugSpeech.asset.meta
+++ b/Assets/Game/Speech/z_Debug/DebugSpeech.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 40251be01b2924d569124d202f679f64
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/_Debug/TEST_BattleRoyale.unity
+++ b/Assets/Scenes/_Debug/TEST_BattleRoyale.unity
@@ -77965,11 +77965,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9140000498525693428, guid: 9bf5874c37e0a404a9bd916129a14959, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.76
+      value: -5.48
       objectReference: {fileID: 0}
     - target: {fileID: 9140000498525693428, guid: 9bf5874c37e0a404a9bd916129a14959, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -5.69
+      value: -6.13
       objectReference: {fileID: 0}
     - target: {fileID: 9140000498525693428, guid: 9bf5874c37e0a404a9bd916129a14959, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Scripts/Combat/BattleLogistics/BattleRewards.cs
+++ b/Assets/Scripts/Combat/BattleLogistics/BattleRewards.cs
@@ -36,10 +36,12 @@ namespace Frankie.Combat
             bool levelUpTriggered = false;
             foreach (BattleEntity character in activePlayerCharacters)
             {
+                if (character.combatParticipant.IsDead()) { continue; } // No experience for dead characters
+                
                 var experience = character.combatParticipant.GetComponent<Experience>();
                 if (experience == null) { continue; } // Handling if characters do not level
+                
                 float scaledExperienceReward = 0f;
-
                 foreach (BattleEntity enemy in enemies)
                 {
                     float rawExperienceReward = enemy.combatParticipant.GetExperienceReward();

--- a/Assets/Scripts/Control/Movement/PlayerMover.cs
+++ b/Assets/Scripts/Control/Movement/PlayerMover.cs
@@ -49,14 +49,14 @@ namespace Frankie.Control
         {
             base.OnEnable();
             playerStateMachine.playerStateChanged += ParsePlayerStateChange;
-            SubscribeToPartyUpdates(true);
+            if (TryGetComponent(out Party party)) { party.SubscribeToMembersAlteredUpdates(true, HandlePartyUpdate); }
         }
 
         protected override void OnDisable()
         {
             base.OnDisable();
             playerStateMachine.playerStateChanged -= ParsePlayerStateChange;
-            SubscribeToPartyUpdates(false);
+            if (TryGetComponent(out Party party)) { party.SubscribeToMembersAlteredUpdates(false, HandlePartyUpdate); }
         }
         
         protected override void FixedUpdate()
@@ -75,13 +75,6 @@ namespace Frankie.Control
             inWorld = (playerStateType == PlayerStateType.InWorld);
             if (playerStateType == PlayerStateType.InCutScene) { inWorld = playerStateContext.CanMoveInCutscene(); }
             RefreshMoverSpeed();
-        }
-
-        private void SubscribeToPartyUpdates(bool enable)
-        {
-            if (!TryGetComponent(out Party party)) { return; }
-            party.membersAltered -= HandlePartyUpdate;
-            if (enable) { party.membersAltered += HandlePartyUpdate; }
         }
 
         private void HandlePartyUpdate(PartyAlteredData partyAlteredData)

--- a/Assets/Scripts/Control/Player/PlayerController.cs
+++ b/Assets/Scripts/Control/Player/PlayerController.cs
@@ -77,21 +77,14 @@ namespace Frankie.Control
         {
             playerInput.Player.Enable();
             playerStateMachine.playerStateChanged += ParsePlayerStateChange;
-            SubscribeToPartyUpdates(true);
+            if (TryGetComponent(out Party party)) { party.SubscribeToMembersAlteredUpdates(true, HandlePartyUpdate); }
         }
 
         private void OnDisable()
         {
             playerInput.Player.Disable();
             playerStateMachine.playerStateChanged -= ParsePlayerStateChange;
-            SubscribeToPartyUpdates(false);
-        }
-        
-        private void SubscribeToPartyUpdates(bool enable)
-        {
-            if (!TryGetComponent(out Party party)) { return; }
-            party.membersAltered -= HandlePartyUpdate;
-            if (enable) { party.membersAltered += HandlePartyUpdate; }
+            if (TryGetComponent(out Party party)) { party.SubscribeToMembersAlteredUpdates(false, HandlePartyUpdate); }
         }
         #endregion
         

--- a/Assets/Scripts/Predicates/Party/AnyCharacterInPartyPredicate.cs
+++ b/Assets/Scripts/Predicates/Party/AnyCharacterInPartyPredicate.cs
@@ -8,13 +8,15 @@ namespace Frankie.Core.Predicates
     [CreateAssetMenu(fileName = "New Any Character In Party Predicate", menuName = "Predicates/Party/Contains Any Character", order = 5)]
     public class AnyCharacterInPartyPredicate : PredicateParty
     {
+        [SerializeField] private PartyBehaviourType partyBehaviourType = PartyBehaviourType.Party;
         [SerializeField] private List<CharacterProperties> charactersToMatch = new();
         
-        public override bool? Evaluate(Party party)
+        public override bool? Evaluate(PartyBehaviour partyBehaviour)
         {
+            if (!PartyBehaviour.IsPartyBehaviourType(partyBehaviour, partyBehaviourType)) { return null; }
             if (charactersToMatch.Count == 0) { return false; }
 
-            foreach (BaseStats baseStats in party.GetMembers())
+            foreach (BaseStats baseStats in partyBehaviour.GetMembers())
             {
                 if (baseStats == null) { continue; }
                 if (charactersToMatch.Any(characterToMatch => CharacterProperties.AreCharacterPropertiesMatched(characterToMatch, baseStats.GetCharacterProperties())))

--- a/Assets/Scripts/Predicates/Party/CharacterIsLeaderPredicate.cs
+++ b/Assets/Scripts/Predicates/Party/CharacterIsLeaderPredicate.cs
@@ -8,12 +8,14 @@ namespace Frankie.Core.Predicates
     [CreateAssetMenu(fileName = "New Character Is Leader Predicate", menuName = "Predicates/Party/Is Character Party Leader", order = 5)]
     public class CharacterIsLeaderPredicate : PredicateParty
     {
+        [SerializeField] private PartyBehaviourType partyBehaviourType = PartyBehaviourType.Party;
         [SerializeField] private List<CharacterProperties> charactersToMatch = new();
         
-        public override bool? Evaluate(Party party)
+        public override bool? Evaluate(PartyBehaviour partyBehaviour)
         {
+            if (!PartyBehaviour.IsPartyBehaviourType(partyBehaviour, partyBehaviourType)) { return null; }
             if (charactersToMatch.Count == 0) { return false; }
-            BaseStats leader = party.GetPartyLeader();
+            BaseStats leader = partyBehaviour.GetPartyLeader();
             return leader != null && charactersToMatch.Any(characterToMatch => CharacterProperties.AreCharacterPropertiesMatched(characterToMatch, leader.GetCharacterProperties()));
         }
     }

--- a/Assets/Scripts/Predicates/Party/PredicateParty.cs
+++ b/Assets/Scripts/Predicates/Party/PredicateParty.cs
@@ -4,6 +4,6 @@ namespace Frankie.Core.Predicates
 {
     public abstract class PredicateParty : Predicate
     {
-        public abstract bool? Evaluate(Party party);
+        public abstract bool? Evaluate(PartyBehaviour partyBehaviour);
     }
 }

--- a/Assets/Scripts/Saving/SavingSystem.cs
+++ b/Assets/Scripts/Saving/SavingSystem.cs
@@ -17,7 +17,7 @@ namespace Frankie.Saving
         // Constants
         private const string _saveFileExtension = ".sav";
         private const string _saveLastSceneBuildIndex = "lastSceneBuildIndex";
-        private const bool _encryptionEnabled = false;
+        private const bool _encryptionEnabled = true;
 
         #region DataStructures
         [System.Serializable]

--- a/Assets/Scripts/Sound/BackgroundMusic.cs
+++ b/Assets/Scripts/Sound/BackgroundMusic.cs
@@ -169,9 +169,9 @@ namespace Frankie.Sound
             currentWorldMusic = audioClip;
             isWorldMusicLooping = isLooping;
             
-            if (BackgroundMusicOverride.TryGetHighestPriorityActiveOverride(out BackgroundMusicOverride backgroundMusicOverride) && backgroundMusicOverride.HasAudioOverride())
+            if (BackgroundMusicOverride.TryGetOverrideAudio(out AudioClip overrideAudio))
             {
-                OverrideMusic(backgroundMusicOverride.GetAudioClip());
+                OverrideMusic(overrideAudio);
                 return;
             }
             

--- a/Assets/Scripts/Sound/BackgroundMusicOverride.cs
+++ b/Assets/Scripts/Sound/BackgroundMusicOverride.cs
@@ -35,7 +35,7 @@ namespace Frankie.Sound
             _backgroundMusicOverrides.Remove(backgroundMusicOverride);
         }
 
-        public static bool TryGetHighestPriorityActiveOverride(out BackgroundMusicOverride highestPriorityOverride)
+        private static bool TryGetHighestPriorityActiveOverride(out BackgroundMusicOverride highestPriorityOverride)
         {
             highestPriorityOverride = null;
             foreach (BackgroundMusicOverride backgroundMusicOverride in _backgroundMusicOverrides.Where(backgroundMusicOverride => backgroundMusicOverride.isOverrideActive))
@@ -46,6 +46,25 @@ namespace Frankie.Sound
                 }
             }
             return highestPriorityOverride != null;
+        }
+
+        public static bool TryGetOverrideAudio(out AudioClip audioClip)
+        {
+            audioClip = null;
+            for (int i =  0; i < _backgroundMusicOverrides.Count; i++)
+            {
+                if (!TryGetHighestPriorityActiveOverride(out BackgroundMusicOverride backgroundMusicOverride)) { return false; }
+
+                if (backgroundMusicOverride.HasAudioOverride())
+                {
+                    audioClip = backgroundMusicOverride.GetAudioClip();
+                    return true;
+                }
+                
+                // Invalid Configuration -- Disable and iterate until we get something
+                backgroundMusicOverride.TriggerOverride(false);
+            }
+            return false;
         }
         #endregion
         
@@ -65,9 +84,8 @@ namespace Frankie.Sound
         }
         #endregion
 
-        #region UtilityMethods
+        #region PublicMethods
         public bool HasAudioOverride() => audioClip != null;
-        public AudioClip GetAudioClip() => audioClip;
         public void TriggerOverride(bool enable) // Callable via Unity Events
         {
             BackgroundMusic backgroundMusic = BackgroundMusic.FindBackgroundMusic();
@@ -79,7 +97,10 @@ namespace Frankie.Sound
         {
             TriggerOverride(!isOverrideActive);
         }
+        #endregion
 
+        #region PrivateMethods
+        private AudioClip GetAudioClip() => audioClip;
         private int GetPriority() => priority;
         private void TriggerOverride(bool enable, BackgroundMusic backgroundMusic)
         {

--- a/Assets/Scripts/Speech/Editor/DialogueEditor.cs
+++ b/Assets/Scripts/Speech/Editor/DialogueEditor.cs
@@ -115,7 +115,8 @@ namespace Frankie.Speech.Editor
             if (dialogueNameLabel != null) { dialogueNameLabel.text = hasDialogue ? selectedDialogue.name : string.Empty; }
             
             if (!hasDialogue) { return; }
-            connectionsLayer.SetDialogue(selectedDialogue);
+
+            connectionsLayer?.SetDialogue(selectedDialogue);
             foreach (DialogueNode dialogueNode in selectedDialogue.GetAllNodes())
             {
                 if (dialogueNode == null) { continue; }
@@ -126,6 +127,7 @@ namespace Frankie.Speech.Editor
 
         private void AddNodeView(DialogueNode dialogueNode)
         {
+            if (nodeViews == null) { return; }
             var view = new DialogueNodeView(dialogueNode, selectedDialogue, MarkConnectionsDirty, () => zoomManipulator.zoomFactor);
             view.speakerNameChanged += HandleSpeakerNameChanged;
             view.speakerTypeChanged += HandleSpeakerTypeChanged;
@@ -237,6 +239,7 @@ namespace Frankie.Speech.Editor
 
         private void RefreshLinkButtons()
         {
+            if (nodeViews == null) { return; }
             foreach (DialogueNodeView view in nodeViews.Values)
             {
                 DialogueNode node = view.dialogueNode;

--- a/Assets/Scripts/Stats/Party/Party.cs
+++ b/Assets/Scripts/Stats/Party/Party.cs
@@ -3,14 +3,13 @@ using System.Linq;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Frankie.Saving;
-using Frankie.Core.Predicates;
 using Frankie.Combat;
 using Frankie.Control;
 
 namespace Frankie.Stats
 {
     [RequireComponent(typeof(InactiveParty))]
-    public class Party : PartyBehaviour, ISaveable<PartySaveData>, IPredicateEvaluator
+    public class Party : PartyBehaviour, ISaveable<PartySaveData>
     {
         // State
         private readonly HashSet<CharacterProperties> unlockedCharacters = new();
@@ -68,15 +67,6 @@ namespace Frankie.Stats
         #endregion
 
         #region PublicGetters
-        public bool IsPartyLeader(BaseStats checkMember) => checkMember != null && (members?[0] == checkMember);
-        public BaseStats GetPartyLeader() => members?[0];
-        public GameObject GetPartyLeaderObject()
-        {
-            BaseStats partyLeader = members[0];
-            return partyLeader != null ? partyLeader.gameObject : null;
-        }
-        public string GetPartyLeaderName() => members[0]?.GetCharacterProperties()?.GetCharacterDisplayName() ?? "";
-        public int GetPartySize() => members.Count;
         public IList<CharacterProperties> GetAvailableCharactersToAdd()
         {
             List<CharacterProperties> charactersInParty = members.Select(character => character.GetCharacterProperties()).ToList();
@@ -280,14 +270,6 @@ namespace Frankie.Stats
                 members.AddRange(deadMembers);
             }
             return stateModified;
-        }
-        #endregion
-
-        #region PredicateInterface
-        public bool? Evaluate(Predicate predicate)
-        {
-            var predicateParty = predicate as PredicateParty;
-            return predicateParty != null ? predicateParty.Evaluate(this) : null;
         }
         #endregion
         

--- a/Assets/Scripts/Stats/Party/Party.cs
+++ b/Assets/Scripts/Stats/Party/Party.cs
@@ -48,7 +48,7 @@ namespace Frankie.Stats
         #endregion
         
         #region EventHandling
-        protected override PartyAlteredData PackPartyAlteredData() => new(members, GetPartyLeaderName(), GetLeadCharacterAnimator());
+        protected override PartyAlteredData PackPartyAlteredData() => new(PartyBehaviourType.Party, members, GetPartyLeaderName(), GetLeadCharacterAnimator());
 
         private void HandlePlayerStateUpdates(PlayerStateType playerStateType, IPlayerStateContext playerStateContext)
         {

--- a/Assets/Scripts/Stats/Party/PartyAlteredData.cs
+++ b/Assets/Scripts/Stats/Party/PartyAlteredData.cs
@@ -15,12 +15,14 @@ namespace Frankie.Stats
         
         public PartyAlteredData(PartyBehaviourType partyBehaviourType, List<BaseStats> members)
         {
+            this.partyBehaviourType = partyBehaviourType;
             this.members = members != null ? members.ToList() : new List<BaseStats>();
             isPartyLeaderDataSet = false;
         }
 
         public PartyAlteredData(PartyBehaviourType partyBehaviourType, List<BaseStats> members, string partyLeaderName, Animator partyLeaderAnimator)
         {
+            this.partyBehaviourType = partyBehaviourType;
             this.members = members != null ? members.ToList() : new List<BaseStats>();
             isPartyLeaderDataSet = true;
             this.partyLeaderName = partyLeaderName;

--- a/Assets/Scripts/Stats/Party/PartyAlteredData.cs
+++ b/Assets/Scripts/Stats/Party/PartyAlteredData.cs
@@ -7,18 +7,19 @@ namespace Frankie.Stats
 {
     public class PartyAlteredData
     {
+        public PartyBehaviourType partyBehaviourType { get; private set; }
         private readonly List<BaseStats> members;
         public bool isPartyLeaderDataSet { get; private set; } = false;
         public string partyLeaderName { get; private set; } = string.Empty;
         public Animator partyLeaderAnimator { get; private set; }
         
-        public PartyAlteredData(List<BaseStats> members)
+        public PartyAlteredData(PartyBehaviourType partyBehaviourType, List<BaseStats> members)
         {
             this.members = members != null ? members.ToList() : new List<BaseStats>();
             isPartyLeaderDataSet = false;
         }
 
-        public PartyAlteredData(List<BaseStats> members, string partyLeaderName, Animator partyLeaderAnimator)
+        public PartyAlteredData(PartyBehaviourType partyBehaviourType, List<BaseStats> members, string partyLeaderName, Animator partyLeaderAnimator)
         {
             this.members = members != null ? members.ToList() : new List<BaseStats>();
             isPartyLeaderDataSet = true;

--- a/Assets/Scripts/Stats/Party/PartyAssist.cs
+++ b/Assets/Scripts/Stats/Party/PartyAssist.cs
@@ -20,6 +20,7 @@ namespace Frankie.Stats
         #endregion
 
         #region AbstractImplementations
+        protected override PartyAlteredData PackPartyAlteredData() => new(PartyBehaviourType.PartyAssist, members);
         protected override int GetInitialPartyOffset() => party.GetLastMemberOffsetIndex() + partyOffset;
         protected override bool ShouldSkipFirstEntryOffset() => false;
 

--- a/Assets/Scripts/Stats/Party/PartyBehaviour.cs
+++ b/Assets/Scripts/Stats/Party/PartyBehaviour.cs
@@ -33,7 +33,7 @@ namespace Frankie.Stats
         protected PlayerStateMachine playerStateMachine;
         
         // Events
-        public event Action<PartyAlteredData> membersAltered;
+        private event Action<PartyAlteredData> membersAltered;
         
         #region StaticMethods
         public static bool IsPartyBehaviourType(PartyBehaviour partyBehaviour, PartyBehaviourType partyBehaviourType)
@@ -93,7 +93,7 @@ namespace Frankie.Stats
         }
 
         protected void TriggerMembersAltered() => membersAltered?.Invoke(PackPartyAlteredData());
-        protected virtual PartyAlteredData PackPartyAlteredData() => new(members);
+        protected abstract PartyAlteredData PackPartyAlteredData();
         
         protected void RefreshLookups()
         {

--- a/Assets/Scripts/Stats/Party/PartyBehaviour.cs
+++ b/Assets/Scripts/Stats/Party/PartyBehaviour.cs
@@ -4,13 +4,14 @@ using System.Linq;
 using UnityEngine;
 using Frankie.Control;
 using Frankie.Combat;
+using Frankie.Core.Predicates;
 using Frankie.Utils;
 
 namespace Frankie.Stats
 {
     [RequireComponent(typeof(PlayerMover))]
     [RequireComponent(typeof(PlayerStateMachine))]
-    public abstract class PartyBehaviour : MonoBehaviour
+    public abstract class PartyBehaviour : MonoBehaviour, IPredicateEvaluator
     {
         // Tunables
         [SerializeField][Range(1, 8)] protected int partyLimit = 4;
@@ -33,6 +34,20 @@ namespace Frankie.Stats
         
         // Events
         public event Action<PartyAlteredData> membersAltered;
+        
+        #region StaticMethods
+        public static bool IsPartyBehaviourType(PartyBehaviour partyBehaviour, PartyBehaviourType partyBehaviourType)
+        {
+            switch (partyBehaviour)
+            {
+                case Party when partyBehaviourType == PartyBehaviourType.Party:
+                case PartyAssist when partyBehaviourType == PartyBehaviourType.PartyAssist:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+        #endregion
         
         #region UnityMethods
         protected virtual void Awake()
@@ -116,9 +131,18 @@ namespace Frankie.Stats
         #endregion
 
         #region PublicMethods
+        public bool IsPartyLeader(BaseStats checkMember) => checkMember != null && (members?[0] == checkMember);
+        public BaseStats GetPartyLeader() => members?[0];
+        public GameObject GetPartyLeaderObject()
+        {
+            BaseStats partyLeader = members[0];
+            return partyLeader != null ? partyLeader.gameObject : null;
+        }
+        public string GetPartyLeaderName() => members[0]?.GetCharacterProperties()?.GetCharacterDisplayName() ?? "";
+        
         public List<BaseStats> GetMembers() => members;
+        public int GetPartySize() => members.Count;
         public int GetLastMemberOffsetIndex() => lastMemberOffsetIndex;
-
         public BaseStats GetMember(CharacterProperties matchCharacterProperties)
         {
             return members.FirstOrDefault(baseStats => CharacterProperties.AreCharacterPropertiesMatched(matchCharacterProperties, baseStats.GetCharacterProperties()));
@@ -190,6 +214,14 @@ namespace Frankie.Stats
                 characterSpriteLink.SetInteractionProbeLayer(probeLayer);
                 characterSpriteLink.SetIsFlashing(isPlayerImmune);
             }
+        }
+        #endregion
+        
+        #region PredicateInterface
+        public bool? Evaluate(Predicate predicate)
+        {
+            var predicateParty = predicate as PredicateParty;
+            return predicateParty != null ? predicateParty.Evaluate(this) : null;
         }
         #endregion
     }

--- a/Assets/Scripts/Stats/Party/PartyBehaviourType.cs
+++ b/Assets/Scripts/Stats/Party/PartyBehaviourType.cs
@@ -1,0 +1,8 @@
+namespace Frankie.Stats
+{
+    public enum PartyBehaviourType
+    {
+        Party,
+        PartyAssist
+    }
+}

--- a/Assets/Scripts/Stats/Party/PartyBehaviourType.cs.meta
+++ b/Assets/Scripts/Stats/Party/PartyBehaviourType.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 95061f318f6b423ead1270b25ef39b04
+timeCreated: 1783789369

--- a/Assets/Scripts/Stats/Party/PartyCombatConduit.cs
+++ b/Assets/Scripts/Stats/Party/PartyCombatConduit.cs
@@ -94,22 +94,6 @@ namespace Frankie.Stats
             }
         }
 
-        private void SubscribeToLeaderStatusUpdates(bool enable)
-        {
-            if (combatParticipantCache.Count == 0) { return; }
-            CombatParticipant partyLeader = combatParticipantCache[0];
-            if (partyLeader == null) { return; }
-
-            if (enable)
-            {
-                partyLeader.SubscribeToStateUpdates(HandleLeaderStatusUpdate);
-            }
-            else
-            {
-                partyLeader.UnsubscribeToStateUpdates(HandleLeaderStatusUpdate);
-            }
-        }
-
         private void RefreshMembersCache(PartyAlteredData partyAlteredData)
         {
             Action<CombatParticipant> refreshAction = null;
@@ -140,6 +124,22 @@ namespace Frankie.Stats
                 {
                     refreshAction(combatParticipant);
                 }
+            }
+        }
+        
+        private void SubscribeToLeaderStatusUpdates(bool enable)
+        {
+            if (combatParticipantCache.Count == 0) { return; }
+            CombatParticipant partyLeader = combatParticipantCache[0];
+            if (partyLeader == null) { return; }
+
+            if (enable)
+            {
+                partyLeader.SubscribeToStateUpdates(HandleLeaderStatusUpdate);
+            }
+            else
+            {
+                partyLeader.UnsubscribeToStateUpdates(HandleLeaderStatusUpdate);
             }
         }
         #endregion

--- a/Assets/Scripts/Stats/Party/PartyCombatConduit.cs
+++ b/Assets/Scripts/Stats/Party/PartyCombatConduit.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Frankie.Combat;
@@ -17,20 +18,20 @@ namespace Frankie.Stats
         {
             if (TryGetComponent(out Party party))
             {
-                party.SubscribeToMembersAlteredUpdates(true, RefreshCombatParticipantCache);
-                RefreshCombatParticipantCache(new PartyAlteredData(party.GetMembers()));
+                party.SubscribeToMembersAlteredUpdates(true, RefreshMembersCache);
+                RefreshMembersCache(new PartyAlteredData(PartyBehaviourType.Party, party.GetMembers()));
             }
             if (TryGetComponent(out PartyAssist partyAssist))
             {
-                partyAssist.SubscribeToMembersAlteredUpdates(true, RefreshCombatAssistCache);
-                RefreshCombatAssistCache(new PartyAlteredData(partyAssist.GetMembers()));
+                partyAssist.SubscribeToMembersAlteredUpdates(true, RefreshMembersCache);
+                RefreshMembersCache(new PartyAlteredData(PartyBehaviourType.PartyAssist, partyAssist.GetMembers()));
             }
         }
 
         private void OnDisable()
         {
-            if (TryGetComponent(out Party party)) { party.SubscribeToMembersAlteredUpdates(false, RefreshCombatParticipantCache); }
-            if (TryGetComponent(out PartyAssist partyAssist)) { partyAssist.SubscribeToMembersAlteredUpdates(true, RefreshCombatAssistCache); }
+            if (TryGetComponent(out Party party)) { party.SubscribeToMembersAlteredUpdates(false, RefreshMembersCache); }
+            if (TryGetComponent(out PartyAssist partyAssist)) { partyAssist.SubscribeToMembersAlteredUpdates(true, RefreshMembersCache); }
         }
         #endregion
 
@@ -109,30 +110,35 @@ namespace Frankie.Stats
             }
         }
 
-        private void RefreshCombatParticipantCache(PartyAlteredData partyAlteredData)
+        private void RefreshMembersCache(PartyAlteredData partyAlteredData)
         {
-            SubscribeToLeaderStatusUpdates(false);
-            combatParticipantCache.Clear();
-            foreach (BaseStats character in partyAlteredData.GetMembers())
+            Action<CombatParticipant> refreshAction = null;
+            switch (partyAlteredData.partyBehaviourType)
             {
-                if (character.TryGetComponent(out CombatParticipant combatParticipant))
+                case PartyBehaviourType.Party:
                 {
-                    combatParticipantCache.Add(combatParticipant);
+                    SubscribeToLeaderStatusUpdates(false);
+                    combatParticipantCache.Clear();
+                    refreshAction = combatParticipant => combatParticipantCache.Add(combatParticipant);
+            
+                    if (partyAlteredData.isPartyLeaderDataSet) { cachedPartyLeaderName = partyAlteredData.partyLeaderName;}
+                    SubscribeToLeaderStatusUpdates(true);
+                    break;
+                }
+                case PartyBehaviourType.PartyAssist:
+                {
+                    combatAssistCache.Clear();
+                    refreshAction = combatParticipant => combatAssistCache.Add(combatParticipant);
+                    break;
                 }
             }
             
-            if (partyAlteredData.isPartyLeaderDataSet) { cachedPartyLeaderName = partyAlteredData.partyLeaderName;}
-            SubscribeToLeaderStatusUpdates(true);
-        }
-
-        private void RefreshCombatAssistCache(PartyAlteredData partyAlteredData)
-        {
-            combatAssistCache.Clear();
+            if (refreshAction == null) { return; }
             foreach (BaseStats character in partyAlteredData.GetMembers())
             {
                 if (character.TryGetComponent(out CombatParticipant combatParticipant))
                 {
-                    combatAssistCache.Add(combatParticipant);
+                    refreshAction(combatParticipant);
                 }
             }
         }

--- a/Assets/Scripts/Stats/Party/PartyKnapsackConduit.cs
+++ b/Assets/Scripts/Stats/Party/PartyKnapsackConduit.cs
@@ -19,7 +19,7 @@ namespace Frankie.Inventory
             if (TryGetComponent(out Party party))
             {
                 party.SubscribeToMembersAlteredUpdates(true , RefreshCache);
-                RefreshCache(new PartyAlteredData(party.GetMembers()));
+                RefreshCache(new PartyAlteredData(PartyBehaviourType.Party, party.GetMembers()));
             }
         }
 


### PR DESCRIPTION
## Background

Already implemented predicates for standard party members, would like to have equivalent for party assist.

## Approach

Move required functionality used in predicates onto PartyBehaviour, then switch predicate to apply to PartyBehaviour.  Add tunable enum selector to define if we want Party or PartyAssist -- predicate evaluate to null for incorrect (i.e. don't know the answer of evaluation).