### PR TITLE
CU-868jyww8v :: Player State Machine Clean-Up

### DIFF
--- a/Assets/Game/CharacterObjects/NPCs/NonPlayableCharacter.prefab
+++ b/Assets/Game/CharacterObjects/NPCs/NonPlayableCharacter.prefab
@@ -582,6 +582,18 @@ MonoBehaviour:
   willForceCombat: 0
   willDestroyIfInvisible: 0
   delayToDestroyAfterInvisible: 2
+  localizedMessageCannotFight:
+    m_TableReference:
+      m_TableCollectionName: GUID:bb484015a3d7647bfba6919a6815d5b0
+    m_TableEntryReference:
+      m_KeyId: 32539111364485120
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  references:
+    version: 2
+    RefIds: []
 --- !u!114 &6372006413732983059
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Game/WorldObjects/Interior/Subway/SubwayTrain/SubwayTrain.prefab
+++ b/Assets/Game/WorldObjects/Interior/Subway/SubwayTrain/SubwayTrain.prefab
@@ -320,6 +320,18 @@ MonoBehaviour:
   willForceCombat: 0
   willDestroyIfInvisible: 0
   delayToDestroyAfterInvisible: 2
+  localizedMessageCannotFight:
+    m_TableReference:
+      m_TableCollectionName: GUID:bb484015a3d7647bfba6919a6815d5b0
+    m_TableEntryReference:
+      m_KeyId: 32539111364485120
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  references:
+    version: 2
+    RefIds: []
 --- !u!114 &999296917510441045
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Localization/Table_Core/Core Shared Data.asset
+++ b/Assets/Localization/Table_Core/Core Shared Data.asset
@@ -115,10 +115,6 @@ MonoBehaviour:
     m_Key: CharacterProperties.Lucy
     m_Metadata:
       m_Items: []
-  - m_Id: 5452253379944448
-    m_Key: PlayerStateMachine.Prefab.Player.MessageCannotFight
-    m_Metadata:
-      m_Items: []
   - m_Id: 5481021502906368
     m_Key: Stat.HP
     m_Metadata:
@@ -237,6 +233,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 7990100041392128
     m_Key: StatusEffect.Debuff.Stoic
+    m_Metadata:
+      m_Items: []
+  - m_Id: 32539111364485120
+    m_Key: NPCStateHandler.Prefab.NonPlayableCharacter.MessageCannotFight.5aad22a6
     m_Metadata:
       m_Items: []
   m_Metadata:

--- a/Assets/Localization/Table_Core/Core_en.asset
+++ b/Assets/Localization/Table_Core/Core_en.asset
@@ -118,10 +118,6 @@ MonoBehaviour:
     m_Localized: Lucy
     m_Metadata:
       m_Items: []
-  - m_Id: 5452253379944448
-    m_Localized: '{0} is wounded and cannot fight.'
-    m_Metadata:
-      m_Items: []
   - m_Id: 5481021502906368
     m_Localized: HP
     m_Metadata:
@@ -240,6 +236,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 7990100041392128
     m_Localized: FRAIL
+    m_Metadata:
+      m_Items: []
+  - m_Id: 32539111364485120
+    m_Localized: '{0} is wounded and cannot fight.'
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Localization/Table_Core/Core_fr.asset
+++ b/Assets/Localization/Table_Core/Core_fr.asset
@@ -118,10 +118,6 @@ MonoBehaviour:
     m_Localized: Lucy
     m_Metadata:
       m_Items: []
-  - m_Id: 5452253379944448
-    m_Localized: "{0} est bless\xE9 et ne peut pas combattre."
-    m_Metadata:
-      m_Items: []
   - m_Id: 5481021502906368
     m_Localized: PV
     m_Metadata:
@@ -240,6 +236,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 7990100041392128
     m_Localized: FRAGILE
+    m_Metadata:
+      m_Items: []
+  - m_Id: 32539111364485120
+    m_Localized: "{0} est bless\xE9 et ne peut pas combattre."
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Scripts/Control/NPC/NPCStateHandler.cs
+++ b/Assets/Scripts/Control/NPC/NPCStateHandler.cs
@@ -1,19 +1,25 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Localization;
+using UnityEngine.Localization.Tables;
 using Frankie.Core;
 using Frankie.Combat;
 using Frankie.Speech;
 using Frankie.ZoneManagement;
+using Frankie.Utils.Localization;
 
 namespace Frankie.Control
 {
-    public class NPCStateHandler : MonoBehaviour
+    public class NPCStateHandler : MonoBehaviour, ILocalizable
     {
         // Tunables
+        [Header("Standard Properties")]
         [SerializeField] private bool willForceCombat = false;
         [SerializeField] private bool willDestroyIfInvisible = false;
         [Min(0)][Tooltip("in seconds")][SerializeField] private float delayToDestroyAfterInvisible = 2f;
+        [Header("Messages : {0} for character name")]
+        [SerializeField][SimpleLocalizedString(LocalizationTableType.Core, true)] private LocalizedString localizedMessageCannotFight;
 
         // State
         private NPCStateType npcState = NPCStateType.Idle;
@@ -30,6 +36,16 @@ namespace Frankie.Control
         // Events
         public event Action<NPCStateType, bool> npcStateChanged;
 
+        // Localization Methods
+        public LocalizationTableType localizationTableType { get; } = LocalizationTableType.Core;
+        public List<TableEntryReference> GetLocalizationEntries()
+        {
+            return new List<TableEntryReference>
+            {
+                localizedMessageCannotFight.TableEntryReference
+            };
+        }
+        
         #region UnityMethods
         private void Awake()
         {
@@ -71,6 +87,11 @@ namespace Frankie.Control
         private void Update()
         {
             UpdateSpriteInvisibilityTimerToDestroy();
+        }
+        
+        private void OnDestroy()
+        {
+            ILocalizable.TriggerOnDestroy(this);
         }
         #endregion
 
@@ -133,7 +154,7 @@ namespace Frankie.Control
 
             if (combatParticipant.IsDead())
             {
-                playerStateMachine.SetupCannotFightPrompt(combatParticipant.GetCombatName());
+                playerStateMachine.EnterDialogue(string.Format(localizedMessageCannotFight.GetSafeLocalizedString(), combatParticipant.GetCombatName()));
                 SetNPCState(NPCStateType.Occupied);
             }
             else

--- a/Assets/Scripts/Control/NPC/NPCStateHandler.cs
+++ b/Assets/Scripts/Control/NPC/NPCStateHandler.cs
@@ -11,6 +11,7 @@ using Frankie.Utils.Localization;
 
 namespace Frankie.Control
 {
+    [ExecuteInEditMode]
     public class NPCStateHandler : MonoBehaviour, ILocalizable
     {
         // Tunables

--- a/Assets/Scripts/Core/PlayerStateMachine.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine.cs
@@ -4,8 +4,6 @@ using System.Collections;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using UnityEngine.Localization;
-using UnityEngine.Localization.Tables;
 using Frankie.Core.PlayerStates;
 using Frankie.Control;
 using Frankie.Combat;
@@ -24,7 +22,7 @@ namespace Frankie.Core
     [RequireComponent(typeof(PartyAssist))]
     [RequireComponent(typeof(PartyCombatConduit))]
     [RequireComponent(typeof(Shopper))]
-    public class PlayerStateMachine : MonoBehaviour, IPlayerStateContext, ILocalizable
+    public class PlayerStateMachine : MonoBehaviour, IPlayerStateContext
     {
         // Tunables
         [Header("Other Controller Prefabs")]
@@ -36,21 +34,9 @@ namespace Frankie.Core
         [SerializeField] private GameObject cashTransferPrefab;
         [SerializeField] private GameObject worldOptionsPrefab;
         [SerializeField] private GameObject escapeMenuPrefab;
-        [Header("Messages : {0} for character name")]
-        [SerializeField][SimpleLocalizedString(LocalizationTableType.Core, true)] private LocalizedString localizedMessageCannotFight;
         [Header("Parameters")]
         [SerializeField] private int maxEnemiesPerCombat = 12;
         [Tooltip("seconds, incl. battle fade-out time")][SerializeField] private float immunityTimePostCombat = 3.5f;
-
-        // Localization Properties
-        public LocalizationTableType localizationTableType { get; } = LocalizationTableType.Core;
-        public List<TableEntryReference> GetLocalizationEntries()
-        {
-            return new List<TableEntryReference>
-            {
-                localizedMessageCannotFight.TableEntryReference
-            };
-        }
         
         // State Information
         // Player
@@ -105,7 +91,7 @@ namespace Frankie.Core
             public Action action { get; }
         }
 
-        #region StaticMethods
+        #region Static
         private static PlayerStateType TranslatePlayerState(IPlayerState playerState)
         {
             Type playerStateType = playerState.GetType();
@@ -116,6 +102,14 @@ namespace Frankie.Core
             if (playerStateType == typeof(CutSceneState)) { return PlayerStateType.InCutScene; }
             return PlayerStateType.InWorld; // Default:  typeof(WorldState)
         }
+        
+        public static TransitionState TransitionState = new();
+        public static CombatState CombatState = new();
+        public static DialogueState DialogueState = new();
+        public static TradeState TradeState = new();
+        public static OptionState OptionState = new();
+        public static CutSceneState CutSceneState = new();
+        public static WorldState WorldState = new();
         #endregion
 
         #region UnityStandardMethods
@@ -144,11 +138,6 @@ namespace Frankie.Core
             readyToPopQueue = false; // Either popped queue will change state, or queue invalidated -- clear state
             PopQueuedAction();
         }
-        
-        private void OnDestroy()
-        {
-            ILocalizable.TriggerOnDestroy(this);
-        }
         #endregion
 
         #region SettersGetters
@@ -158,16 +147,14 @@ namespace Frankie.Core
             Debug.Log($"Updating player state to: {Enum.GetName(typeof(PlayerStateType), playerStateType)}");
 
             currentPlayerState = playerState;
-            
-            
             playerStateChanged?.Invoke(playerStateType, this);
 
             readyToPopQueue = playerStateType == PlayerStateType.InWorld;
             // Pop on update to prevent same-frame multi-state change
             // Otherwise can experience bugs with controller spawning while deconstructing conflicting w/ singleton logic
 
+            // Allow swarm / multi-battle entry on same-frame
             if (playerStateType == PlayerStateType.InTransition && InBattleEntryTransition()) { ChainQueuedCombatAction(); }
-            // Required to allow swarm / multi-battle entry on same-frame
         }
         
         public Party GetParty() => party;
@@ -310,28 +297,14 @@ namespace Frankie.Core
         #region UtilityCombat
         public bool IsAnyPartyMemberAlive() => partyCombatConduit.IsAnyMemberAlive();
         public bool IsPlayerFearsome(CombatParticipant combatParticipant) => partyCombatConduit.IsFearsome(combatParticipant);
-
-        public bool AreCombatParticipantsValid(bool announceCannotFight = false)
-        {
-            if (!partyCombatConduit.IsAnyMemberAlive()) { if (announceCannotFight) { SetupCannotFightPrompt(partyCombatConduit.GetPartyLeaderName()); } return false; }
-            return !enemiesUnderConsideration.All(x => x.IsDead());
-        }
-
-        public void SetupCannotFightPrompt(string entityName)
-        {
-            EnterDialogue(string.Format(localizedMessageCannotFight.GetSafeLocalizedString(), entityName));
-        }
-
+        public bool AreCombatParticipantsValid() => !enemiesUnderConsideration.All(x => x.IsDead());
+ 
         public void AddEnemiesUnderConsideration()
         {
             foreach (CombatParticipant enemy in enemiesUnderConsideration)
             {
                 if (enemiesInTransition.Count > maxEnemiesPerCombat) { return; }
-
-                if (!enemiesInTransition.Contains(enemy))
-                {
-                    enemiesInTransition.Add(enemy);
-                }
+                if (!enemiesInTransition.Contains(enemy)) { enemiesInTransition.Add(enemy); }
             }
         }
 

--- a/Assets/Scripts/Core/PlayerStateMachine.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine.cs
@@ -13,7 +13,6 @@ using Frankie.Inventory;
 using Frankie.World;
 using Frankie.ZoneManagement;
 using Frankie.Utils;
-using Frankie.Utils.Localization;
 
 namespace Frankie.Core
 {
@@ -49,7 +48,6 @@ namespace Frankie.Core
         private TransitionType transitionTypeUnderConsideration = TransitionType.None;
         private TransitionType currentTransitionType = TransitionType.None;
         private bool zoneTransitionComplete = true;
-
         // CutScene
         private bool visibleDuringCutscene = true;
         private bool canMoveInCutscene = false;
@@ -63,6 +61,9 @@ namespace Frankie.Core
         private TradeData tradeData;
         // Option
         private OptionStateType optionStateType;
+        
+        // Coroutines
+        private Coroutine immunityCoroutine;
 
         // Cached References -- Persistent
         private Party party;
@@ -129,6 +130,11 @@ namespace Frankie.Core
         private void OnDisable()
         {
             SceneManager.sceneLoaded -= UpdateReferencesForNewScene;
+        }
+
+        private void OnDestroy()
+        {
+            if (immunityCoroutine != null) { StopCoroutine(immunityCoroutine); }
         }
 
         private void Update()
@@ -371,7 +377,8 @@ namespace Frankie.Core
         private void OnBattleExitPeak()
         {
             BattleEventBus<BattleFadeTransitionEvent>.Raise(new BattleFadeTransitionEvent(BattleFadePhase.ExitPeak));
-            StartCoroutine(TimedCollisionDisable());
+            if (immunityCoroutine != null) { StopCoroutine(immunityCoroutine); }
+            immunityCoroutine = StartCoroutine(TimedCollisionDisable());
         }
 
         private void OnBattleExitComplete()
@@ -475,6 +482,7 @@ namespace Frankie.Core
             SetPlayerImmunity(true);
             yield return new WaitForSeconds(immunityTimePostCombat);
             SetPlayerImmunity(false);
+            immunityCoroutine = null;
         }
         
         public void QueueActionUnderConsideration()
@@ -527,9 +535,12 @@ namespace Frankie.Core
 
             dialogueData = null;
 
-            shopper?.SetShop(null);
-            shopper?.SetBankType(BankType.None);
             tradeData = null;
+            if (shopper != null)
+            {
+                shopper.SetShop(null);
+                shopper.SetBankType(BankType.None);
+            }
 
             optionStateType = OptionStateType.None;
         }

--- a/Assets/Scripts/Core/PlayerStateMachine.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Collections;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Frankie.Core.PlayerStates;
+using Frankie.Core.PlayerStateMemory;
 using Frankie.Control;
 using Frankie.Combat;
 using Frankie.Speech;
@@ -16,7 +16,6 @@ using Frankie.Utils;
 
 namespace Frankie.Core
 {
-    [ExecuteInEditMode]
     [RequireComponent(typeof(Party))]
     [RequireComponent(typeof(PartyAssist))]
     [RequireComponent(typeof(PartyCombatConduit))]
@@ -40,27 +39,14 @@ namespace Frankie.Core
         // State Information
         // Player
         private IPlayerState currentPlayerState = new WorldState();
-        // Queue
-        private PlayerStateTypeActionPair actionUnderConsideration;
-        private readonly Stack<PlayerStateTypeActionPair> queuedActions = new();
-        private bool readyToPopQueue = false;
-        // Transition
-        private TransitionType transitionTypeUnderConsideration = TransitionType.None;
-        private TransitionType currentTransitionType = TransitionType.None;
-        private bool zoneTransitionComplete = true;
-        // CutScene
-        private bool visibleDuringCutscene = true;
-        private bool canMoveInCutscene = false;
-        // Combat
-        private bool combatFadeComplete = false;
-        private readonly List<CombatParticipant> enemiesUnderConsideration = new();
-        private readonly List<CombatParticipant> enemiesInTransition = new();
-        // Dialogue
-        private DialogueData dialogueData;
-        // Trade
-        private TradeData tradeData;
-        // Option
-        private OptionStateType optionStateType;
+        private readonly ActionMemory actionMemory = new();
+        
+        private TransitionMemory transitionMemory = new();
+        private CutsceneMemory cutsceneMemory = new();
+        private CombatMemory combatMemory = new();
+        private DialogueMemory dialogueMemory = new();
+        private TradeMemory tradeMemory = new();
+        private OptionMemory optionMemory = new();
         
         // Coroutines
         private Coroutine immunityCoroutine;
@@ -80,37 +66,16 @@ namespace Frankie.Core
         public event Action<int, int, bool> playerLayerChanged;
 
         // Data Structures
-        private class PlayerStateTypeActionPair
-        {
-            public PlayerStateTypeActionPair(PlayerStateType playerStateType, Action action)
-            {
-                this.playerStateType = playerStateType;
-                this.action = action;
-            }
 
-            public PlayerStateType playerStateType { get; }
-            public Action action { get; }
-        }
 
         #region Static
-        private static PlayerStateType TranslatePlayerState(IPlayerState playerState)
-        {
-            Type playerStateType = playerState.GetType();
-            if (playerStateType == typeof(TransitionState)) { return PlayerStateType.InTransition; }
-            if (playerStateType == typeof(CombatState)) { return PlayerStateType.InBattle; }
-            if (playerStateType == typeof(DialogueState)) { return PlayerStateType.InDialogue; }
-            if (playerStateType == typeof(TradeState) || playerStateType == typeof(OptionState)) { return PlayerStateType.InMenus; }
-            if (playerStateType == typeof(CutSceneState)) { return PlayerStateType.InCutScene; }
-            return PlayerStateType.InWorld; // Default:  typeof(WorldState)
-        }
-        
-        public static TransitionState TransitionState = new();
-        public static CombatState CombatState = new();
-        public static DialogueState DialogueState = new();
-        public static TradeState TradeState = new();
-        public static OptionState OptionState = new();
-        public static CutSceneState CutSceneState = new();
-        public static WorldState WorldState = new();
+        public static readonly TransitionState transitionState = new();
+        public static readonly CombatState combatState = new();
+        public static readonly DialogueState dialogueState = new();
+        public static readonly TradeState tradeState = new();
+        public static readonly OptionState optionState = new();
+        public static readonly CutSceneState cutSceneState = new();
+        public static readonly WorldState worldState = new();
         #endregion
 
         #region UnityStandardMethods
@@ -139,32 +104,29 @@ namespace Frankie.Core
 
         private void Update()
         {
-            if (!readyToPopQueue) { return; }
-            
-            readyToPopQueue = false; // Either popped queue will change state, or queue invalidated -- clear state
-            PopQueuedAction();
+            actionMemory.TryPopQueue();
         }
         #endregion
 
         #region SettersGetters
         void IPlayerStateContext.SetPlayerState(IPlayerState playerState)
         {
-            PlayerStateType playerStateType = TranslatePlayerState(playerState);
+            PlayerStateType playerStateType = playerState.playerStateType;
             Debug.Log($"Updating player state to: {Enum.GetName(typeof(PlayerStateType), playerStateType)}");
 
             currentPlayerState = playerState;
             playerStateChanged?.Invoke(playerStateType, this);
-
-            readyToPopQueue = playerStateType == PlayerStateType.InWorld;
+            actionMemory.SetReadyToPop(playerStateType);
+            
             // Pop on update to prevent same-frame multi-state change
             // Otherwise can experience bugs with controller spawning while deconstructing conflicting w/ singleton logic
 
             // Allow swarm / multi-battle entry on same-frame
-            if (playerStateType == PlayerStateType.InTransition && InBattleEntryTransition()) { ChainQueuedCombatAction(); }
+            if (playerStateType == PlayerStateType.InTransition && InBattleEntryTransition()) { actionMemory.ChainQueuedCombatAction(); }
         }
         
         public Party GetParty() => party;
-        public bool CanMoveInCutscene() => canMoveInCutscene;
+        public bool CanMoveInCutscene() => cutsceneMemory.canMoveInCutscene;
         
         public void SetPostDialogueCallbackActions(InteractionEvent interactionEvent)
         {
@@ -196,21 +158,23 @@ namespace Frankie.Core
 
         public void EnterZoneTransition()
         {
-            queuedActions.Clear(); // Do not carry queued actions across zones
-            actionUnderConsideration = new PlayerStateTypeActionPair(PlayerStateType.InTransition, EnterZoneTransition);
-            currentTransitionType = TransitionType.Zone;
-            zoneTransitionComplete = false;
+            // Do not carry queued actions across zones
+            actionMemory.ClearQueuedActions();
+            actionMemory.SetActionUnderConsideration(PlayerStateType.InTransition, EnterZoneTransition);
+            transitionMemory.currentTransitionType = TransitionType.Zone;
+            transitionMemory.zoneTransitionComplete = false;
+            
             currentPlayerState.EnterTransition(this);
         }
 
         public void EnterCombat(List<CombatParticipant> enemies, TransitionType transitionType)
         {
-            if (enemies == null || enemies.Count == 0 || !IsBattleTransition(transitionType)) { return; }
+            if (enemies == null || enemies.Count == 0 || !TransitionMemory.IsBattleTransition(transitionType)) { return; }
 
-            actionUnderConsideration = new PlayerStateTypeActionPair(PlayerStateType.InBattle, () => EnterCombat(enemies, transitionType));
-            enemiesUnderConsideration.Clear();
-            enemiesUnderConsideration.AddRange(enemies);
-            transitionTypeUnderConsideration = transitionType;
+            actionMemory.SetActionUnderConsideration(PlayerStateType.InBattle, () => EnterCombat(enemies, transitionType));
+            combatMemory.enemiesUnderConsideration.Clear();
+            combatMemory.enemiesUnderConsideration.AddRange(enemies);
+            transitionMemory.transitionTypeUnderConsideration = transitionType;
 
             currentPlayerState.EnterCombat(this);
         }
@@ -219,8 +183,8 @@ namespace Frankie.Core
         {
             if (newConversant == null || newDialogue == null) { return; }
 
-            actionUnderConsideration = new PlayerStateTypeActionPair(PlayerStateType.InDialogue, () => EnterDialogue(newConversant, newDialogue));
-            dialogueData = new DialogueData(newConversant, newDialogue);
+            actionMemory.SetActionUnderConsideration(PlayerStateType.InDialogue, () => EnterDialogue(newConversant, newDialogue));
+            dialogueMemory.dialogueData = new DialogueData(newConversant, newDialogue);
             currentPlayerState.EnterDialogue(this);
         }
 
@@ -228,8 +192,8 @@ namespace Frankie.Core
         {
             if (string.IsNullOrWhiteSpace(message)) { return; }
 
-            actionUnderConsideration = new PlayerStateTypeActionPair(PlayerStateType.InDialogue, () => EnterDialogue(message));
-            dialogueData = new DialogueData(message);
+            actionMemory.SetActionUnderConsideration(PlayerStateType.InDialogue, () => EnterDialogue(message));
+            dialogueMemory.dialogueData = new DialogueData(message);
             currentPlayerState.EnterDialogue(this);
         }
 
@@ -237,8 +201,8 @@ namespace Frankie.Core
         {
             if (choiceActionPairs == null || choiceActionPairs.Count == 0) { return; }
 
-            actionUnderConsideration = new PlayerStateTypeActionPair(PlayerStateType.InDialogue, () => EnterDialogue(message, choiceActionPairs));
-            dialogueData = new DialogueData(message, choiceActionPairs);
+            actionMemory.SetActionUnderConsideration(PlayerStateType.InDialogue, () => EnterDialogue(message, choiceActionPairs));
+            dialogueMemory.dialogueData = new DialogueData(message, choiceActionPairs);
             currentPlayerState.EnterDialogue(this);
         }
 
@@ -246,9 +210,9 @@ namespace Frankie.Core
         {
             if (shopper == null || shop == null) { return; }
 
-            actionUnderConsideration = new PlayerStateTypeActionPair(PlayerStateType.InMenus, () => EnterShop(shop));
+            actionMemory.SetActionUnderConsideration(PlayerStateType.InMenus, () => EnterShop(shop));
             shopper.SetShop(shop);
-            tradeData = new TradeData(shop.GetShopType());
+            tradeMemory.tradeData = new TradeData(shop.GetShopType());
             currentPlayerState.EnterTrade(this);
         }
 
@@ -256,64 +220,49 @@ namespace Frankie.Core
         {
             if (bankType == BankType.None) { return; }
 
-            actionUnderConsideration = new PlayerStateTypeActionPair(PlayerStateType.InMenus, () => EnterBank(bankType));
+            actionMemory.SetActionUnderConsideration(PlayerStateType.InMenus, () => EnterBank(bankType));
             shopper.SetBankType(bankType);
-            tradeData = new TradeData(bankType);
+            tradeMemory.tradeData = new TradeData(bankType);
             currentPlayerState.EnterTrade(this);
         }
 
         public void EnterWorldOptions()
         {
-            optionStateType = OptionStateType.WorldOptions;
+            optionMemory.optionStateType = OptionStateType.WorldOptions;
             currentPlayerState.EnterOptions(this);
         }
 
         public void EnterEscapeMenu()
         {
-            optionStateType = OptionStateType.EscapeMenu;
+            optionMemory.optionStateType = OptionStateType.EscapeMenu;
             currentPlayerState.EnterOptions(this);
         }
 
         public void EnterCutscene(bool playerVisible = true, bool canMove = false)
         {
-            actionUnderConsideration = new PlayerStateTypeActionPair(PlayerStateType.InCutScene, () => EnterCutscene(playerVisible));
-            visibleDuringCutscene = playerVisible;
-            canMoveInCutscene = canMove && playerVisible;
+            actionMemory.SetActionUnderConsideration(PlayerStateType.InCutScene, () => EnterCutscene(playerVisible));
+            cutsceneMemory.visibleDuringCutscene = playerVisible;
+            cutsceneMemory.canMoveInCutscene = canMove && playerVisible;
             currentPlayerState.EnterCutScene(this);
         }
         #endregion
 
         #region UtilityTransition
-        public bool InZoneTransition() => currentTransitionType == TransitionType.Zone;
-        public bool IsZoneTransitionComplete() => zoneTransitionComplete;
-        public void SetZoneTransitionStatus(bool complete)
-        {
-            zoneTransitionComplete = complete;
-        }
-        public void ConfirmTransitionType()
-        {
-            currentTransitionType = transitionTypeUnderConsideration;
-        }
-
-        private static bool IsBattleTransition(TransitionType transitionType) => transitionType is TransitionType.BattleNeutral or TransitionType.BattleGood or TransitionType.BattleBad;
-        public bool InBattleEntryTransition() => IsBattleTransition(currentTransitionType);
-        public bool InBattleExitTransition() => currentTransitionType == TransitionType.BattleComplete;
+        
+        public bool InZoneTransition() => transitionMemory.currentTransitionType == TransitionType.Zone;
+        public bool IsZoneTransitionComplete() => transitionMemory.zoneTransitionComplete;
+        public void SetZoneTransitionStatus(bool complete) => transitionMemory.zoneTransitionComplete = complete;
+        public void ConfirmTransitionType() => transitionMemory.ConfirmTransitionType();
+        public bool InBattleEntryTransition() => transitionMemory.InBattleEntryTransition();
+        public bool InBattleExitTransition() => transitionMemory.InBattleExitTransition();
         #endregion
 
         #region UtilityCombat
+        public bool IsCombatFadeComplete() => combatMemory.combatFadeComplete;
         public bool IsAnyPartyMemberAlive() => partyCombatConduit.IsAnyMemberAlive();
         public bool IsPlayerFearsome(CombatParticipant combatParticipant) => partyCombatConduit.IsFearsome(combatParticipant);
-        public bool AreCombatParticipantsValid() => !enemiesUnderConsideration.All(x => x.IsDead());
- 
-        public void AddEnemiesUnderConsideration()
-        {
-            foreach (CombatParticipant enemy in enemiesUnderConsideration)
-            {
-                if (enemiesInTransition.Count > maxEnemiesPerCombat) { return; }
-                if (!enemiesInTransition.Contains(enemy)) { enemiesInTransition.Add(enemy); }
-            }
-        }
-
+        public bool AreCombatParticipantsValid() => combatMemory.AreCombatParticipantsValid();
+        public void ConfirmEnemiesUnderConsideration() => combatMemory.ShiftEnemiesFromConsiderationToTransition(maxEnemiesPerCombat);
         public void SetupBattleController()
         {
             if (battleController == null)
@@ -328,50 +277,43 @@ namespace Frankie.Core
         {
             // Edge case on improper game exit, starting Coroutine on object if it's undergoing destruction throws error
             if (this == null || gameObject == null) { return false; }
-
-            combatFadeComplete = false;
+            
+            TransitionType currentTransitionType = transitionMemory.currentTransitionType;
             var faderEventTriggers = new FaderEventTriggers(null, () => OnBattleEntryPeak(currentTransitionType), null, () => OnBattleEntryComplete(currentTransitionType));
-            bool faderInitiated = Fader.StartStandardFade(currentTransitionType, faderEventTriggers);
-
-            if (!faderInitiated) { combatFadeComplete = true; }
-            return faderInitiated;
+            return combatMemory.BeginFade(currentTransitionType, faderEventTriggers);
         }
-
-        public bool IsCombatFadeComplete() => combatFadeComplete;
 
         public bool EndBattleSequence()
         {
             // Edge case on improper game exit, starting Coroutine on object if it's undergoing destruction throws error
             if (this == null || gameObject == null) { return false; }
 
-            currentTransitionType = TransitionType.BattleComplete;
+            transitionMemory.currentTransitionType = TransitionType.BattleComplete;
             var faderEventTriggers = new FaderEventTriggers(null, OnBattleExitPeak, null, OnBattleExitComplete);
-            
-            return Fader.StartStandardFade(currentTransitionType, faderEventTriggers);
+            return combatMemory.ConcludeFade(TransitionType.BattleComplete, faderEventTriggers);
         }
 
         private void HandleCombatMessages(BattleStateChangedEvent battleStateChangedEvent)
         {
             BattleState battleState = battleStateChangedEvent.battleState;
-
             if (battleState != BattleState.Complete) { return; }
+            
             BattleEventBus<BattleStateChangedEvent>.UnsubscribeFromEvent(HandleCombatMessages);
-
-            currentTransitionType = TransitionType.BattleComplete;
+            transitionMemory.currentTransitionType = TransitionType.BattleComplete;
             currentPlayerState.EnterTransition(this);
         }
         
         private void OnBattleEntryPeak(TransitionType transitionType)
         {
             if (battleUIPrefab != null) { Instantiate(battleUIPrefab); }
-            BattleEventBus<BattleFadeTransitionEvent>.Raise(new BattleFadeTransitionEvent(BattleFadePhase.EntryPeak, enemiesInTransition, transitionType));
+            BattleEventBus<BattleFadeTransitionEvent>.Raise(new BattleFadeTransitionEvent(BattleFadePhase.EntryPeak, combatMemory.enemiesInTransition, transitionType));
         }
 
         private void OnBattleEntryComplete(TransitionType transitionType)
         {
-            combatFadeComplete = true;
+            combatMemory.combatFadeComplete = true;
             currentPlayerState.EnterCombat(this);
-            BattleEventBus<BattleFadeTransitionEvent>.Raise(new BattleFadeTransitionEvent(BattleFadePhase.EntryComplete, enemiesInTransition, transitionType));
+            BattleEventBus<BattleFadeTransitionEvent>.Raise(new BattleFadeTransitionEvent(BattleFadePhase.EntryComplete, combatMemory.enemiesInTransition, transitionType));
         }
 
         private void OnBattleExitPeak()
@@ -396,85 +338,36 @@ namespace Frankie.Core
                 DialogueController existingDialogueController = DialogueController.FindDialogueController();
                 dialogueController = existingDialogueController == null ? Instantiate(dialogueControllerPrefab) : existingDialogueController;
             }
-
             dialogueController.Setup(worldCanvas, this, party);
         }
 
-        public bool StartDialogueSequence()
-        {
-            if (dialogueData == null) { return false; }
-
-            DialogueDataType dialogueDataType = dialogueData.dialogueDataType;
-            switch (dialogueDataType)
-            {
-                case DialogueDataType.StandardDialogue:
-                    dialogueController?.InitiateConversation(dialogueData.aiConversant, dialogueData.dialogue);
-                    break;
-                case DialogueDataType.SimpleText:
-                    dialogueController?.InitiateSimpleMessage(dialogueData.message);
-                    break;
-                case DialogueDataType.SimpleChoice:
-                    dialogueController?.InitiateSimpleOption(dialogueData.message, dialogueData.choiceActionPairs);
-                    break;
-                default:
-                    return false;
-            }
-            return true;
-        }
+        public bool StartDialogueSequence() => dialogueMemory.InitiateDialogue(dialogueController);
         #endregion
 
         #region UtilityTrade
         public bool StartTradeSequence()
         {
-            if (tradeData == null) { return false; }
-            switch (tradeData.tradeDataType)
-            {
-                case TradeDataType.Shop:
-                    Instantiate(shopSelectPrefab, worldCanvas.gameObject.transform);
-                    break;
-                case TradeDataType.Bank:
-                    Instantiate(cashTransferPrefab, worldCanvas.gameObject.transform);
-                    break;
-                case TradeDataType.None:
-                    return false;
-            }
-            return true;
+            return tradeMemory.InitiateTrade(
+                () => Instantiate(shopSelectPrefab, worldCanvas.gameObject.transform),
+                () => Instantiate(cashTransferPrefab, worldCanvas.gameObject.transform));
         }
         #endregion
 
         #region UtilityOption
         public bool StartOptionSequence()
         {
-            switch (optionStateType)
-            {
-                case OptionStateType.WorldOptions:
-                    Instantiate(worldOptionsPrefab, worldCanvas.gameObject.transform);
-                    break;
-                case OptionStateType.EscapeMenu:
-                    Instantiate(escapeMenuPrefab, worldCanvas.gameObject.transform);
-                    break;
-                case OptionStateType.None:
-                default:
-                    return false;
-            }
-            return true;
+            return optionMemory.InitiateOptions(
+                () => Instantiate(worldOptionsPrefab, worldCanvas.gameObject.transform), 
+                () => Instantiate(escapeMenuPrefab, worldCanvas.gameObject.transform));
         }
-
         #endregion
 
         #region UtilityGeneral
         public void TogglePlayerVisibility(bool? enable = null)
         {
-            bool visible = enable ?? visibleDuringCutscene;
-
-            if (party != null)
-            {
-                party.TogglePartyVisible(visible);
-            }
-            if (partyAssist != null)
-            {
-                partyAssist.TogglePartyVisible(visible);
-            }
+            bool visible = enable ?? cutsceneMemory.visibleDuringCutscene;
+            if (party != null) { party.TogglePartyVisible(visible); }
+            if (partyAssist != null) { partyAssist.TogglePartyVisible(visible); }
         }
         
         private IEnumerator TimedCollisionDisable()
@@ -484,65 +377,28 @@ namespace Frankie.Core
             SetPlayerImmunity(false);
             immunityCoroutine = null;
         }
-        
-        public void QueueActionUnderConsideration()
-        {
-            if (actionUnderConsideration?.action == null) { return; }
-            queuedActions.Push(actionUnderConsideration);
-        }
 
-        private void PopQueuedAction()
-        {
-            if (queuedActions.Count == 0) { return; }
-            
-            PlayerStateTypeActionPair nextQueuedAction = queuedActions.Pop();
-            nextQueuedAction.action?.Invoke();
-
-            if (nextQueuedAction.playerStateType == PlayerStateType.InBattle)
-            {
-                // On combat allow chained queues (e.g. multiple combat instantiation while in dialogue)
-                ChainQueuedCombatAction();
-            }
-        }
-
-        private void ChainQueuedCombatAction()
-        {
-            if (queuedActions.Count > 0 && queuedActions.Peek().playerStateType == PlayerStateType.InBattle)
-            {
-                PopQueuedAction();
-            }
-        }
+        public void QueueActionUnderConsideration() => actionMemory.QueueActionUnderConsideration();
 
         public void ClearPlayerStateMemory()
         {
-            // Kill controllers
             battleController = null;
             dialogueController = null;
-
-            // Clear State
-            actionUnderConsideration = null;
-
-            transitionTypeUnderConsideration = TransitionType.None;
-            currentTransitionType = TransitionType.None;
-            zoneTransitionComplete = true;
-
-            canMoveInCutscene = false;
-            visibleDuringCutscene = true;
-
-            combatFadeComplete = false;
-            enemiesUnderConsideration.Clear();
-            enemiesInTransition.Clear();
-
-            dialogueData = null;
-
-            tradeData = null;
             if (shopper != null)
             {
                 shopper.SetShop(null);
                 shopper.SetBankType(BankType.None);
             }
-
-            optionStateType = OptionStateType.None;
+            
+            // Note:  We do NOT call a new ActionMemory here, as QueuedActions must persist
+            actionMemory.ResetActionUnderConsideration();
+            
+            transitionMemory = new TransitionMemory();
+            cutsceneMemory = new CutsceneMemory();
+            combatMemory = new CombatMemory();
+            dialogueMemory = new DialogueMemory();
+            tradeMemory = new TradeMemory();
+            optionMemory = new OptionMemory();
         }
         #endregion
     }

--- a/Assets/Scripts/Core/PlayerStateMachine/IPlayerStateContext.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/IPlayerStateContext.cs
@@ -24,7 +24,7 @@ namespace Frankie.Core
         #region Combat
         public bool IsAnyPartyMemberAlive();
         public bool IsPlayerFearsome(CombatParticipant combatParticipant);
-        public bool AreCombatParticipantsValid(bool announceCannotFight = false);
+        public bool AreCombatParticipantsValid();
         public void AddEnemiesUnderConsideration();
         public void SetupBattleController();
         public bool StartBattleSequence();

--- a/Assets/Scripts/Core/PlayerStateMachine/IPlayerStateContext.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/IPlayerStateContext.cs
@@ -2,47 +2,49 @@ using Frankie.Combat;
 
 namespace Frankie.Core
 {
-    public interface IPlayerStateContext
+    public interface IPlayerStateContext : ITransitionStateContext, ICombatStateContext, IDialogueStateContext, ITradeStateContext, IOptionStateContext
     {
         void SetPlayerState(IPlayerState playerState);
+        void TogglePlayerVisibility(bool? enable = null);
+        void QueueActionUnderConsideration();
+        bool CanMoveInCutscene();
+        void ClearPlayerStateMemory();
+    }
 
-        #region Utility
-        public void TogglePlayerVisibility(bool? enable = null);
-        public void QueueActionUnderConsideration();
-        public bool CanMoveInCutscene();
-        public void ClearPlayerStateMemory();
-        #endregion
+    public interface ITransitionStateContext
+    {
+        void ConfirmTransitionType();
+        bool InZoneTransition();
+        bool IsZoneTransitionComplete();
+        bool InBattleEntryTransition();
+        bool InBattleExitTransition();
+    }
 
-        #region Transition
-        public void ConfirmTransitionType();
-        public bool InZoneTransition();
-        public bool IsZoneTransitionComplete();
-        public bool InBattleEntryTransition();
-        public bool InBattleExitTransition();
-        #endregion
+    public interface ICombatStateContext
+    {
+        bool IsAnyPartyMemberAlive();
+        bool IsPlayerFearsome(CombatParticipant combatParticipant);
+        bool AreCombatParticipantsValid();
+        void ConfirmEnemiesUnderConsideration();
+        void SetupBattleController();
+        bool StartBattleSequence();
+        bool IsCombatFadeComplete();
+        bool EndBattleSequence();
+    }
 
-        #region Combat
-        public bool IsAnyPartyMemberAlive();
-        public bool IsPlayerFearsome(CombatParticipant combatParticipant);
-        public bool AreCombatParticipantsValid();
-        public void AddEnemiesUnderConsideration();
-        public void SetupBattleController();
-        public bool StartBattleSequence();
-        public bool IsCombatFadeComplete();
-        public bool EndBattleSequence();
-        #endregion
-        
-        #region Dialogue
-        public void SetupDialogueController();
-        public bool StartDialogueSequence();
-        #endregion
+    public interface IDialogueStateContext
+    {
+        void SetupDialogueController();
+        bool StartDialogueSequence();
+    }
 
-        #region Trade
-        public bool StartTradeSequence();
-        #endregion
+    public interface ITradeStateContext
+    {
+        bool StartTradeSequence();
+    }
 
-        #region Option
-        public bool StartOptionSequence();
-        #endregion
+    public interface IOptionStateContext
+    {
+        bool StartOptionSequence();
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory.meta
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4bb23329d7654241a0c1d82c21b7ce98
+timeCreated: 1784135459

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/ActionMemory.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/ActionMemory.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+
+namespace Frankie.Core.PlayerStateMemory
+{
+    public class ActionMemory
+    {
+        // Parameters
+        private PlayerStateTypeActionPair actionUnderConsideration;
+        private readonly Stack<PlayerStateTypeActionPair> queuedActions = new();
+        private bool readyToPopQueue = false;
+        
+        #region DataStructures
+        private class PlayerStateTypeActionPair
+        {
+            public PlayerStateType playerStateType { get; }
+            public Action action { get; }
+            
+            public PlayerStateTypeActionPair(PlayerStateType playerStateType, Action action)
+            {
+                this.playerStateType = playerStateType;
+                this.action = action;
+            }
+        }
+        #endregion
+        
+        #region PublicMethods
+        public void ResetActionUnderConsideration() => actionUnderConsideration = null;
+        public void ClearQueuedActions() => queuedActions.Clear();
+        
+        public void SetReadyToPop(PlayerStateType playerStateType) => readyToPopQueue = playerStateType == PlayerStateType.InWorld;
+        public void SetActionUnderConsideration(PlayerStateType playerStateType, Action action) => actionUnderConsideration = new PlayerStateTypeActionPair(playerStateType, action); 
+        
+        public void QueueActionUnderConsideration()
+        {
+            if (actionUnderConsideration?.action == null) { return; }
+            queuedActions.Push(actionUnderConsideration);
+        }
+        
+        public void TryPopQueue()
+        {
+            if (!readyToPopQueue) { return; }
+            readyToPopQueue = false; // Either popped queue will change state, or queue invalidated -- clear state
+            PopQueuedAction();
+        }
+        
+        public void ChainQueuedCombatAction(PlayerStateType playerStateType = PlayerStateType.InBattle)
+        {
+            while (true)
+            {
+                // On combat allow chained queues (e.g. multiple combat instantiation while in dialogue)
+                if (playerStateType != PlayerStateType.InBattle) { return; }
+                if (queuedActions.Count == 0 || queuedActions.Peek().playerStateType != PlayerStateType.InBattle) { return; }
+                if (!TryActivateNextQueuedAction(out playerStateType)) { return; }
+            }
+        }
+        #endregion
+        
+        #region PrivateMethods
+        private void PopQueuedAction()
+        {
+            if (!TryActivateNextQueuedAction(out PlayerStateType playerStateType)) { return; }
+            ChainQueuedCombatAction(playerStateType);
+        }
+
+        private bool TryActivateNextQueuedAction(out PlayerStateType playerStateType)
+        {
+            playerStateType = PlayerStateType.InWorld;
+            if (queuedActions.Count == 0) { return false; }
+            
+            PlayerStateTypeActionPair nextQueuedAction = queuedActions.Pop();
+            playerStateType = nextQueuedAction.playerStateType;
+            nextQueuedAction.action?.Invoke();
+            return true;
+        }
+        #endregion
+    }
+}

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/ActionMemory.cs.meta
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/ActionMemory.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e01f61a7ca6f499c9cac78841f08458e
+timeCreated: 1784142124

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/CombatMemory.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/CombatMemory.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using Frankie.Combat;
+using Frankie.ZoneManagement;
+
+namespace Frankie.Core.PlayerStateMemory
+{
+    public class CombatMemory
+    {
+        public bool combatFadeComplete = false;
+        public readonly List<CombatParticipant> enemiesUnderConsideration = new();
+        public readonly List<CombatParticipant> enemiesInTransition = new();
+        
+        public bool AreCombatParticipantsValid() => !enemiesUnderConsideration.All(x => x.IsDead());
+
+        public void ShiftEnemiesFromConsiderationToTransition(int maxEnemiesPerCombat)
+        {
+            foreach (CombatParticipant enemy in enemiesUnderConsideration)
+            {
+                if (enemiesInTransition.Count > maxEnemiesPerCombat) { return; }
+                if (!enemiesInTransition.Contains(enemy)) { enemiesInTransition.Add(enemy); }
+            }
+        }
+
+        public bool BeginFade(TransitionType currentTransitionType, FaderEventTriggers faderEventTriggers)
+        {
+            combatFadeComplete = false;
+            bool faderInitiated = Fader.StartStandardFade(currentTransitionType, faderEventTriggers);
+            if (!faderInitiated) { combatFadeComplete = true; }
+            return faderInitiated;
+        }
+
+        public bool ConcludeFade(TransitionType currentTransitionType, FaderEventTriggers faderEventTriggers) => Fader.StartStandardFade(currentTransitionType, faderEventTriggers);
+    }
+}

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/CombatMemory.cs.meta
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/CombatMemory.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 10a4c291980341d29f911c9f72839f87
+timeCreated: 1784135596

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/CutsceneMemory.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/CutsceneMemory.cs
@@ -1,0 +1,8 @@
+namespace Frankie.Core.PlayerStateMemory
+{
+    public class CutsceneMemory
+    {
+        public bool visibleDuringCutscene = true;
+        public bool canMoveInCutscene = false;
+    }
+}

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/CutsceneMemory.cs.meta
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/CutsceneMemory.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 25ed119f351c4b70bcefc7a5c658ad81
+timeCreated: 1784135580

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/DialogueMemory.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/DialogueMemory.cs
@@ -1,0 +1,29 @@
+using Frankie.Speech;
+
+namespace Frankie.Core.PlayerStateMemory
+{
+    public class DialogueMemory
+    {
+        public DialogueData dialogueData;
+
+        public bool InitiateDialogue(DialogueController dialogueController)
+        {
+            if (dialogueController == null || dialogueData == null) { return false; }
+            switch (dialogueData.dialogueDataType)
+            {
+                case DialogueDataType.StandardDialogue:
+                    dialogueController.InitiateConversation(dialogueData.aiConversant, dialogueData.dialogue);
+                    break;
+                case DialogueDataType.SimpleText:
+                    dialogueController.InitiateSimpleMessage(dialogueData.message);
+                    break;
+                case DialogueDataType.SimpleChoice:
+                    dialogueController.InitiateSimpleOption(dialogueData.message, dialogueData.choiceActionPairs);
+                    break;
+                default:
+                    return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/DialogueMemory.cs.meta
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/DialogueMemory.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7ca44c332a724fd4b7055306607ba107
+timeCreated: 1784135669

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/OptionMemory.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/OptionMemory.cs
@@ -1,0 +1,29 @@
+using System;
+using Frankie.Core.PlayerStates;
+
+namespace Frankie.Core.PlayerStateMemory
+{
+    public class OptionMemory
+    {
+        public OptionStateType optionStateType = OptionStateType.None;
+
+        public bool InitiateOptions(Action instantiateWorldOptions, Action instantiateEscapeMenu)
+        {
+            switch (optionStateType)
+            {
+                case OptionStateType.WorldOptions:
+                    if (instantiateWorldOptions == null) { return false; }
+                    instantiateWorldOptions.Invoke();
+                    break;
+                case OptionStateType.EscapeMenu:
+                    if (instantiateEscapeMenu == null) { return false; }
+                    instantiateEscapeMenu.Invoke();
+                    break;
+                case OptionStateType.None:
+                default:
+                    return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/OptionMemory.cs.meta
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/OptionMemory.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c776af8712124b93996e67cbfd47d4ce
+timeCreated: 1784135736

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/TradeMemory.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/TradeMemory.cs
@@ -1,0 +1,29 @@
+using System;
+using Frankie.Inventory;
+
+namespace Frankie.Core.PlayerStateMemory
+{
+    public class TradeMemory
+    {
+        public TradeData tradeData;
+
+        public bool InitiateTrade(Action instantiateShop, Action instantiateBank)
+        {
+            if (tradeData == null) { return false; }
+            switch (tradeData.tradeDataType)
+            {
+                case TradeDataType.Shop:
+                    if (instantiateShop == null) { return false; }
+                    instantiateShop.Invoke();
+                    break;
+                case TradeDataType.Bank:
+                    if (instantiateBank == null) { return false; }
+                    instantiateBank.Invoke();
+                    break;
+                case TradeDataType.None:
+                    return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/TradeMemory.cs.meta
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/TradeMemory.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cb11c46a08d940e689745bcc056138f5
+timeCreated: 1784135711

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/TransitionMemory.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/TransitionMemory.cs
@@ -1,0 +1,16 @@
+using Frankie.ZoneManagement;
+
+namespace Frankie.Core.PlayerStateMemory
+{
+    public class TransitionMemory
+    {
+        public TransitionType transitionTypeUnderConsideration = TransitionType.None;
+        public TransitionType currentTransitionType = TransitionType.None;
+        public bool zoneTransitionComplete = true;
+        
+        public static bool IsBattleTransition(TransitionType transitionType) => transitionType is TransitionType.BattleNeutral or TransitionType.BattleGood or TransitionType.BattleBad;
+        public void ConfirmTransitionType() => currentTransitionType = transitionTypeUnderConsideration;
+        public bool InBattleEntryTransition() => IsBattleTransition(currentTransitionType);
+        public bool InBattleExitTransition() => currentTransitionType == TransitionType.BattleComplete;
+    }
+}

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/TransitionMemory.cs.meta
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStateMemory/TransitionMemory.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 755afa663ae647fab03965336ae5bebf
+timeCreated: 1784135478

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/CombatState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/CombatState.cs
@@ -31,7 +31,7 @@ namespace Frankie.Core.PlayerStates
         {
             if (playerStateContext.InBattleExitTransition())
             {
-                playerStateContext.SetPlayerState(new TransitionState());
+                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState);
                 if (!playerStateContext.EndBattleSequence())  // State change from Transition to World handled by coroutine
                 {
                     EnterWorld(playerStateContext); // Protection to default back to world on fail to exit battle
@@ -39,14 +39,14 @@ namespace Frankie.Core.PlayerStates
             }
             else if (playerStateContext.InZoneTransition())
             {
-                playerStateContext.SetPlayerState(new TransitionState()); // Force state to transition, going to get pulled to a new scene
+                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState); // Force state to transition, going to get pulled to a new scene
             }
         }
 
         public void EnterWorld(IPlayerStateContext playerStateContext) // Kill rogue controllers for safety, unexpected to call this route
         {
             playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(new WorldState());
+            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
         }
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/CombatState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/CombatState.cs
@@ -1,37 +1,17 @@
 namespace Frankie.Core.PlayerStates
 {
-    public class CombatState : IPlayerState
+    public class CombatState : PlayerStateBase
     {
-        public void EnterCombat(IPlayerStateContext playerStateContext)
-        {
-            // Ignore - go to immunity post-combat, so cannot queue
-        }
+        public override PlayerStateType playerStateType => PlayerStateType.InBattle;
 
-        public void EnterCutScene(IPlayerStateContext playerStateContext)
-        {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
-        }
+        // Ignore - go to immunity post-combat, so cannot queue
+        public override void EnterCombat(IPlayerStateContext playerStateContext) { }
 
-        public void EnterDialogue(IPlayerStateContext playerStateContext)
-        {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
-        }
-
-        public void EnterOptions(IPlayerStateContext playerStateContext) // Ignore
-        {
-        }
-
-        public void EnterTrade(IPlayerStateContext playerStateContext) // Ignore
-        {
-        }
-
-        public void EnterTransition(IPlayerStateContext playerStateContext)
+        public override void EnterTransition(IPlayerStateContext playerStateContext)
         {
             if (playerStateContext.InBattleExitTransition())
             {
-                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState);
+                playerStateContext.SetPlayerState(PlayerStateMachine.transitionState);
                 if (!playerStateContext.EndBattleSequence())  // State change from Transition to World handled by coroutine
                 {
                     EnterWorld(playerStateContext); // Protection to default back to world on fail to exit battle
@@ -39,14 +19,8 @@ namespace Frankie.Core.PlayerStates
             }
             else if (playerStateContext.InZoneTransition())
             {
-                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState); // Force state to transition, going to get pulled to a new scene
+                playerStateContext.SetPlayerState(PlayerStateMachine.transitionState); // Force state to transition, going to get pulled to a new scene
             }
-        }
-
-        public void EnterWorld(IPlayerStateContext playerStateContext) // Kill rogue controllers for safety, unexpected to call this route
-        {
-            playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
         }
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/CutSceneState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/CutSceneState.cs
@@ -1,48 +1,30 @@
 namespace Frankie.Core.PlayerStates
 {
-    public class CutSceneState : IPlayerState
+    public class CutSceneState : PlayerStateBase
     {
-        public void EnterCombat(IPlayerStateContext playerStateContext)
-        {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
-        }
-
-        public void EnterCutScene(IPlayerStateContext playerStateContext)
+        public override PlayerStateType playerStateType => PlayerStateType.InCutScene;
+        
+        public override void EnterCutScene(IPlayerStateContext playerStateContext)
         {
             // Queue then kick to world to bump next cutscene immediately
             playerStateContext.QueueActionUnderConsideration();
             EnterWorld(playerStateContext);
         }
 
-        public void EnterDialogue(IPlayerStateContext playerStateContext)
+        public override void EnterTransition(IPlayerStateContext playerStateContext)
         {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
+            if (!playerStateContext.InZoneTransition()) { return; }
+            
+            // Force state to transition, going to get pulled to a new scene
+            playerStateContext.TogglePlayerVisibility(true);
+            playerStateContext.SetPlayerState(PlayerStateMachine.transitionState); 
         }
 
-        public void EnterOptions(IPlayerStateContext playerStateContext)
-        {
-        }
-
-        public void EnterTrade(IPlayerStateContext playerStateContext)
-        {
-        }
-
-        public void EnterTransition(IPlayerStateContext playerStateContext)
-        {
-            if (playerStateContext.InZoneTransition())
-            {
-                playerStateContext.TogglePlayerVisibility(true);
-                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState); // Force state to transition, going to get pulled to a new scene
-            }
-        }
-
-        public void EnterWorld(IPlayerStateContext playerStateContext)
+        public override void EnterWorld(IPlayerStateContext playerStateContext)
         {
             playerStateContext.TogglePlayerVisibility(true);
             playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
+            playerStateContext.SetPlayerState(PlayerStateMachine.worldState);
         }
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/CutSceneState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/CutSceneState.cs
@@ -34,7 +34,7 @@ namespace Frankie.Core.PlayerStates
             if (playerStateContext.InZoneTransition())
             {
                 playerStateContext.TogglePlayerVisibility(true);
-                playerStateContext.SetPlayerState(new TransitionState()); // Force state to transition, going to get pulled to a new scene
+                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState); // Force state to transition, going to get pulled to a new scene
             }
         }
 
@@ -42,7 +42,7 @@ namespace Frankie.Core.PlayerStates
         {
             playerStateContext.TogglePlayerVisibility(true);
             playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(new WorldState());
+            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
         }
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/DialogueState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/DialogueState.cs
@@ -34,14 +34,14 @@ namespace Frankie.Core.PlayerStates
         {
             if (playerStateContext.InZoneTransition())
             {
-                playerStateContext.SetPlayerState(new TransitionState()); // Force state to transition, going to get pulled to a new scene
+                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState); // Force state to transition, going to get pulled to a new scene
             }
         }
 
         public void EnterWorld(IPlayerStateContext playerStateContext)
         {
             playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(new WorldState());
+            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
         }
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/DialogueState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/DialogueState.cs
@@ -1,47 +1,8 @@
 namespace Frankie.Core.PlayerStates
 {
-    public class DialogueState : IPlayerState
+    public class DialogueState : PlayerStateBase
     {
-        public void EnterCombat(IPlayerStateContext playerStateContext)
-        {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
-        }
-
-        public void EnterCutScene(IPlayerStateContext playerStateContext)
-        {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
-        }
-
-        public void EnterDialogue(IPlayerStateContext playerStateContext)
-        {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
-        }
-
-        public void EnterOptions(IPlayerStateContext playerStateContext) // Ignore
-        {
-        }
-
-        public void EnterTrade(IPlayerStateContext playerStateContext)
-        {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
-        }
-
-        public void EnterTransition(IPlayerStateContext playerStateContext)
-        {
-            if (playerStateContext.InZoneTransition())
-            {
-                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState); // Force state to transition, going to get pulled to a new scene
-            }
-        }
-
-        public void EnterWorld(IPlayerStateContext playerStateContext)
-        {
-            playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
-        }
+        public override PlayerStateType playerStateType => PlayerStateType.InDialogue;
+        public override void EnterTrade(IPlayerStateContext playerStateContext) => playerStateContext.QueueActionUnderConsideration();
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/IPlayerState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/IPlayerState.cs
@@ -2,6 +2,7 @@ namespace Frankie.Core
 {
     public interface IPlayerState
     {
+        PlayerStateType playerStateType { get; }
         void EnterWorld(IPlayerStateContext playerStateContext);
         void EnterTransition(IPlayerStateContext playerStateContext);
         void EnterCombat(IPlayerStateContext playerStateContext);

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/OptionState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/OptionState.cs
@@ -1,45 +1,7 @@
 namespace Frankie.Core.PlayerStates
 {
-    public class OptionState : IPlayerState
+    public class OptionState : PlayerStateBase
     {
-        public void EnterCombat(IPlayerStateContext playerStateContext)
-        {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
-        }
-
-        public void EnterCutScene(IPlayerStateContext playerStateContext)
-        {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
-        }
-
-        public void EnterDialogue(IPlayerStateContext playerStateContext)
-        {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
-        }
-
-        public void EnterOptions(IPlayerStateContext playerStateContext) // Ignore
-        {
-        }
-
-        public void EnterTrade(IPlayerStateContext playerStateContext) // Ignore
-        {
-        }
-
-        public void EnterTransition(IPlayerStateContext playerStateContext)
-        {
-            if (playerStateContext.InZoneTransition())
-            {
-                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState); // Force state to transition, going to get pulled to a new scene
-            }
-        }
-
-        public void EnterWorld(IPlayerStateContext playerStateContext)
-        {
-            playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
-        }
+        public override PlayerStateType playerStateType => PlayerStateType.InMenus;
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/OptionState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/OptionState.cs
@@ -32,14 +32,14 @@ namespace Frankie.Core.PlayerStates
         {
             if (playerStateContext.InZoneTransition())
             {
-                playerStateContext.SetPlayerState(new TransitionState()); // Force state to transition, going to get pulled to a new scene
+                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState); // Force state to transition, going to get pulled to a new scene
             }
         }
 
         public void EnterWorld(IPlayerStateContext playerStateContext)
         {
             playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(new WorldState());
+            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
         }
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/PlayerStateBase.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/PlayerStateBase.cs
@@ -1,0 +1,24 @@
+namespace Frankie.Core.PlayerStates
+{
+    public abstract class PlayerStateBase : IPlayerState
+    {
+        public abstract PlayerStateType playerStateType { get; }
+        public virtual void EnterCombat(IPlayerStateContext playerStateContext) => playerStateContext.QueueActionUnderConsideration();
+        public virtual void EnterDialogue(IPlayerStateContext playerStateContext) => playerStateContext.QueueActionUnderConsideration();
+        public virtual void EnterCutScene(IPlayerStateContext playerStateContext) => playerStateContext.QueueActionUnderConsideration();
+        public virtual void EnterOptions(IPlayerStateContext playerStateContext) { } // Ignore
+        public virtual void EnterTrade(IPlayerStateContext playerStateContext) { } // Ignore
+
+        public virtual void EnterTransition(IPlayerStateContext playerStateContext)
+        {
+            // Force state to transition, going to get pulled to a new scene
+            if (playerStateContext.InZoneTransition()) { playerStateContext.SetPlayerState(PlayerStateMachine.transitionState); }
+        }
+
+        public virtual void EnterWorld(IPlayerStateContext playerStateContext)
+        {
+            playerStateContext.ClearPlayerStateMemory();
+            playerStateContext.SetPlayerState(PlayerStateMachine.worldState);
+        }
+    }
+}

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/PlayerStateBase.cs.meta
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/PlayerStateBase.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 403df12f10e34807961861f3a34cf652
+timeCreated: 1784129896

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/TradeState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/TradeState.cs
@@ -1,45 +1,7 @@
 namespace Frankie.Core.PlayerStates
 {
-    public class TradeState : IPlayerState
+    public class TradeState : PlayerStateBase
     {
-        public void EnterCombat(IPlayerStateContext playerStateContext)
-        {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
-        }
-
-        public void EnterCutScene(IPlayerStateContext playerStateContext)
-        {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
-        }
-
-        public void EnterDialogue(IPlayerStateContext playerStateContext)
-        {
-            // No state change (will dequeue next time in world)
-            playerStateContext.QueueActionUnderConsideration();
-        }
-
-        public void EnterOptions(IPlayerStateContext playerStateContext) // Ignore
-        {
-        }
-
-        public void EnterTrade(IPlayerStateContext playerStateContext) // Ignore
-        {
-        }
-
-        public void EnterTransition(IPlayerStateContext playerStateContext)
-        {
-            if (playerStateContext.InZoneTransition())
-            {
-                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState); // Force state to transition, going to get pulled to a new scene
-            }
-        }
-
-        public void EnterWorld(IPlayerStateContext playerStateContext)
-        {
-            playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
-        }
+        public override PlayerStateType playerStateType => PlayerStateType.InMenus;
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/TradeState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/TradeState.cs
@@ -32,14 +32,14 @@ namespace Frankie.Core.PlayerStates
         {
             if (playerStateContext.InZoneTransition())
             {
-                playerStateContext.SetPlayerState(new TransitionState()); // Force state to transition, going to get pulled to a new scene
+                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState); // Force state to transition, going to get pulled to a new scene
             }
         }
 
         public void EnterWorld(IPlayerStateContext playerStateContext)
         {
             playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(new WorldState());
+            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
         }
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/TransitionState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/TransitionState.cs
@@ -6,7 +6,7 @@ namespace Frankie.Core.PlayerStates
         {
             if (playerStateContext.IsCombatFadeComplete())
             {
-                playerStateContext.SetPlayerState(new CombatState());
+                playerStateContext.SetPlayerState(PlayerStateMachine.CombatState);
             }
             else
             {
@@ -45,7 +45,7 @@ namespace Frankie.Core.PlayerStates
         {
             if (playerStateContext.InZoneTransition())
             {
-                playerStateContext.SetPlayerState(new TransitionState()); // Force state to transition, going to get pulled to a new scene
+                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState); // Force state to transition, going to get pulled to a new scene
             }
         }
 
@@ -54,7 +54,7 @@ namespace Frankie.Core.PlayerStates
             if (playerStateContext.InZoneTransition() && !playerStateContext.IsZoneTransitionComplete()) { return; } // Hold in transition if still ongoing
 
             playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(new WorldState());
+            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
         }
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/TransitionState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/TransitionState.cs
@@ -1,60 +1,39 @@
 namespace Frankie.Core.PlayerStates
 {
-    public class TransitionState : IPlayerState
+    public class TransitionState : PlayerStateBase
     {
-        public void EnterCombat(IPlayerStateContext playerStateContext)
+        public override PlayerStateType playerStateType => PlayerStateType.InTransition;
+        
+        public override void EnterCombat(IPlayerStateContext playerStateContext)
         {
             if (playerStateContext.IsCombatFadeComplete())
             {
-                playerStateContext.SetPlayerState(PlayerStateMachine.CombatState);
+                playerStateContext.SetPlayerState(PlayerStateMachine.combatState);
             }
             else
             {
-                if (playerStateContext.InBattleEntryTransition() && playerStateContext.AreCombatParticipantsValid()) // Swarm mechanic
-                {
-                    playerStateContext.AddEnemiesUnderConsideration();
-                }
+                // Swarm mechanic
+                if (playerStateContext.InBattleEntryTransition() && playerStateContext.AreCombatParticipantsValid()) { playerStateContext.ConfirmEnemiesUnderConsideration(); }
             }
         }
 
-        public void EnterCutScene(IPlayerStateContext playerStateContext)
+        public override void EnterCutScene(IPlayerStateContext playerStateContext)
         {
-            if (playerStateContext.InBattleEntryTransition())
-            {
-                playerStateContext.QueueActionUnderConsideration();
-            }
+            if (playerStateContext.InBattleEntryTransition()) { playerStateContext.QueueActionUnderConsideration(); }
         }
 
-        public void EnterDialogue(IPlayerStateContext playerStateContext)
+        public override void EnterDialogue(IPlayerStateContext playerStateContext)
         {
-            if (playerStateContext.InBattleEntryTransition())
-            {
-                playerStateContext.QueueActionUnderConsideration();
-            }
+            if (playerStateContext.InBattleEntryTransition()) { playerStateContext.QueueActionUnderConsideration(); }
         }
 
-        public void EnterOptions(IPlayerStateContext playerStateContext) // Ignore
+        public override void EnterWorld(IPlayerStateContext playerStateContext)
         {
-        }
-
-        public void EnterTrade(IPlayerStateContext playerStateContext) // Ignore
-        {
-        }
-
-        public void EnterTransition(IPlayerStateContext playerStateContext)
-        {
-            if (playerStateContext.InZoneTransition())
-            {
-                playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState); // Force state to transition, going to get pulled to a new scene
-            }
-        }
-
-        public void EnterWorld(IPlayerStateContext playerStateContext)
-        {
-            if (playerStateContext.InZoneTransition() && !playerStateContext.IsZoneTransitionComplete()) { return; } // Hold in transition if still ongoing
+            // Hold in transition if still ongoing
+            if (playerStateContext.InZoneTransition() && !playerStateContext.IsZoneTransitionComplete()) { return; }
 
             playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
+            playerStateContext.SetPlayerState(PlayerStateMachine.worldState);
         }
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/WorldState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/WorldState.cs
@@ -1,61 +1,57 @@
 namespace Frankie.Core.PlayerStates
 {
-    public class WorldState : IPlayerState
+    public class WorldState : PlayerStateBase
     {
-        public void EnterCombat(IPlayerStateContext playerStateContext)
+        public override PlayerStateType playerStateType => PlayerStateType.InWorld;
+        
+        public override void EnterCombat(IPlayerStateContext playerStateContext)
         {
             if (!playerStateContext.AreCombatParticipantsValid()) { EnterWorld(playerStateContext); return; }
 
             playerStateContext.SetupBattleController();
-            playerStateContext.AddEnemiesUnderConsideration();
+            playerStateContext.ConfirmEnemiesUnderConsideration();
             playerStateContext.ConfirmTransitionType();
-            playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState);
+            playerStateContext.SetPlayerState(PlayerStateMachine.transitionState);
             if (!playerStateContext.StartBattleSequence())  // State change from Transition to Combat handled by coroutine
             {
                 EnterWorld(playerStateContext); // Protection to default back to world on fail to enter battle
             }
         }
 
-        public void EnterCutScene(IPlayerStateContext playerStateContext)
+        public override void EnterCutScene(IPlayerStateContext playerStateContext)
         {
             playerStateContext.TogglePlayerVisibility();
-            playerStateContext.SetPlayerState(PlayerStateMachine.CutSceneState);
+            playerStateContext.SetPlayerState(PlayerStateMachine.cutSceneState);
         }
 
-        public void EnterDialogue(IPlayerStateContext playerStateContext)
+        public override void EnterDialogue(IPlayerStateContext playerStateContext)
         {
             playerStateContext.SetupDialogueController();
             if (playerStateContext.StartDialogueSequence())
             {
-                playerStateContext.SetPlayerState(PlayerStateMachine.DialogueState);
+                playerStateContext.SetPlayerState(PlayerStateMachine.dialogueState);
             }
         }
 
-        public void EnterOptions(IPlayerStateContext playerStateContext)
+        public override void EnterOptions(IPlayerStateContext playerStateContext)
         {
             if (playerStateContext.StartOptionSequence())
             {
-                playerStateContext.SetPlayerState(PlayerStateMachine.OptionState);
+                playerStateContext.SetPlayerState(PlayerStateMachine.optionState);
             }
         }
 
-        public void EnterTrade(IPlayerStateContext playerStateContext)
+        public override void EnterTrade(IPlayerStateContext playerStateContext)
         {
             if (playerStateContext.StartTradeSequence())
             {
-                playerStateContext.SetPlayerState(PlayerStateMachine.TradeState);
+                playerStateContext.SetPlayerState(PlayerStateMachine.tradeState);
             }
         }
 
-        public void EnterTransition(IPlayerStateContext playerStateContext)
+        public override void EnterTransition(IPlayerStateContext playerStateContext)
         {
-            playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState);
-        }
-
-        public void EnterWorld(IPlayerStateContext playerStateContext)
-        {
-            playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
+            playerStateContext.SetPlayerState(PlayerStateMachine.transitionState);
         }
     }
 }

--- a/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/WorldState.cs
+++ b/Assets/Scripts/Core/PlayerStateMachine/PlayerStates/WorldState.cs
@@ -9,7 +9,7 @@ namespace Frankie.Core.PlayerStates
             playerStateContext.SetupBattleController();
             playerStateContext.AddEnemiesUnderConsideration();
             playerStateContext.ConfirmTransitionType();
-            playerStateContext.SetPlayerState(new TransitionState());
+            playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState);
             if (!playerStateContext.StartBattleSequence())  // State change from Transition to Combat handled by coroutine
             {
                 EnterWorld(playerStateContext); // Protection to default back to world on fail to enter battle
@@ -19,7 +19,7 @@ namespace Frankie.Core.PlayerStates
         public void EnterCutScene(IPlayerStateContext playerStateContext)
         {
             playerStateContext.TogglePlayerVisibility();
-            playerStateContext.SetPlayerState(new CutSceneState());
+            playerStateContext.SetPlayerState(PlayerStateMachine.CutSceneState);
         }
 
         public void EnterDialogue(IPlayerStateContext playerStateContext)
@@ -27,7 +27,7 @@ namespace Frankie.Core.PlayerStates
             playerStateContext.SetupDialogueController();
             if (playerStateContext.StartDialogueSequence())
             {
-                playerStateContext.SetPlayerState(new DialogueState());
+                playerStateContext.SetPlayerState(PlayerStateMachine.DialogueState);
             }
         }
 
@@ -35,7 +35,7 @@ namespace Frankie.Core.PlayerStates
         {
             if (playerStateContext.StartOptionSequence())
             {
-                playerStateContext.SetPlayerState(new OptionState());
+                playerStateContext.SetPlayerState(PlayerStateMachine.OptionState);
             }
         }
 
@@ -43,19 +43,19 @@ namespace Frankie.Core.PlayerStates
         {
             if (playerStateContext.StartTradeSequence())
             {
-                playerStateContext.SetPlayerState(new TradeState());
+                playerStateContext.SetPlayerState(PlayerStateMachine.TradeState);
             }
         }
 
         public void EnterTransition(IPlayerStateContext playerStateContext)
         {
-            playerStateContext.SetPlayerState(new TransitionState());
+            playerStateContext.SetPlayerState(PlayerStateMachine.TransitionState);
         }
 
         public void EnterWorld(IPlayerStateContext playerStateContext)
         {
             playerStateContext.ClearPlayerStateMemory();
-            playerStateContext.SetPlayerState(new WorldState());
+            playerStateContext.SetPlayerState(PlayerStateMachine.WorldState);
         }
     }
 }

--- a/Assets/Scripts/UI/UIBox/UIBox.cs
+++ b/Assets/Scripts/UI/UIBox/UIBox.cs
@@ -114,6 +114,7 @@ namespace Frankie.Utils.UI
         {
             if (controller != null && handleGlobalInput)
             {
+                controller.globalInput -= HandleGlobalInputWrapper;
                 controller.globalInput += HandleGlobalInputWrapper;
             }
             SetUpChoiceOptions();
@@ -380,6 +381,7 @@ namespace Frankie.Utils.UI
 
             if (gameObject.activeSelf)
             {
+                globalInputHandler.globalInput -= HandleGlobalInputWrapper;
                 globalInputHandler.globalInput += HandleGlobalInputWrapper; // Unsubscribed on OnDisable
             }
             // No behaviour if disabled, will subscribe by OnEnable

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.5.3f1
-m_EditorVersionWithRevision: 6000.5.3f1 (c2eb47b3a2a9)
+m_EditorVersion: 6000.5.4f1
+m_EditorVersionWithRevision: 6000.5.4f1 (d550df8bd089)


### PR DESCRIPTION
## Overview

Significant overhaul / clean-up on PlayerStateMachine for readability + maintainability.

No intended gameplay changes. Verified state-by-state against the pre-refactor logic, including edge cases (swarm combat entry, zone-transition holds, cutscene re-queueing) and the action-queue chaining logic.  Also verified via demo play-through.

## High-Level Changes

* Segregated IPlayerStateContext into per-concern interfaces (ITransitionStateContext, ICombatStateContext, IDialogueStateContext, ITradeStateContext, IOptionStateContext)
    * composed back into IPlayerStateContext — no change to the IPlayerState contract
* Extracted PlayerStateBase with sensible virtual defaults (queue-and-hold for Combat/Dialogue/CutScene, ignore for Options/Trade, gated transition/world-entry)
    * Concrete states now only override where behavior actually diverges
    * OptionState/TradeState are empty subclasses
* Grouped loose fields into dedicated memory classes (TransitionMemory, CombatMemory, DialogueMemory, TradeMemory, OptionMemory, CutsceneMemory, ActionMemory) 
    * each owning its own related data
    * and, where it made sense, the logic that operates on it
* ClearPlayerStateMemory() now replaces most memory groups wholesale (= new TransitionMemory(), etc.) instead of resetting fields one by one 
    * new fields on any of these classes are automatically safe by default, with nothing left to remember to clear
    * ActionMemory is the deliberate exception, since queuedActions must survive
* Replaced the TranslatePlayerState type-switch lookup with an abstract PlayerStateType playerStateType { get; } on IPlayerState/PlayerStateBase

++ misc minor changes